### PR TITLE
Support multiple targets in connection menu (multi-navigation)

### DIFF
--- a/src/data/composite/composite.ts
+++ b/src/data/composite/composite.ts
@@ -103,6 +103,7 @@ export class CompositeDataProvider implements DataProvider {
 
     connectedLinkStats(params: {
         elementId: ElementIri;
+        inexactCount?: boolean;
         signal?: AbortSignal;
     }): Promise<LinkCount[]> {
         return this.requestWithMerge(p => p.connectedLinkStats(params), mergeConnectedLinkStats);

--- a/src/data/composite/mergeUtils.ts
+++ b/src/data/composite/mergeUtils.ts
@@ -200,6 +200,7 @@ function mergeLinkCount(a: LinkCount, b: LinkCount): LinkCount {
         ...b,
         inCount: a.inCount + b.inCount,
         outCount: a.outCount + b.outCount,
+        inexact: Boolean(a.inexact || b.inexact),
     };
 }
 

--- a/src/data/decorated/decoratedDataProvider.ts
+++ b/src/data/decorated/decoratedDataProvider.ts
@@ -102,6 +102,7 @@ export class DecoratedDataProvider implements DataProvider {
 
     connectedLinkStats(params: {
         elementId: ElementIri;
+        inexactCount?: boolean;
         signal?: AbortSignal;
     }): Promise<LinkCount[]> {
         return this.decorate('connectedLinkStats', [params]);

--- a/src/data/decorated/indexedDbCachedProvider.ts
+++ b/src/data/decorated/indexedDbCachedProvider.ts
@@ -285,9 +285,10 @@ export class IndexedDbCachedProvider implements DataProvider {
 
     async connectedLinkStats(params: {
         elementId: ElementIri;
+        inexactCount?: boolean;
         signal?: AbortSignal | undefined;
     }): Promise<LinkCount[]> {
-        const {elementId, signal} = params;
+        const {elementId, inexactCount, signal} = params;
         const db = await this.openDb();
         const result = await fetchSingleWithDbCache(
             db,
@@ -295,7 +296,11 @@ export class IndexedDbCachedProvider implements DataProvider {
             elementId,
             async (key): Promise<ConnectedLinkStatsRecord> => ({
                 elementId: key,
-                stats: await this.baseProvider.connectedLinkStats({elementId: key, signal}),
+                stats: await this.baseProvider.connectedLinkStats({
+                    elementId: key,
+                    inexactCount,
+                    signal
+                }),
             })
         );
         return result.stats;

--- a/src/data/model.ts
+++ b/src/data/model.ts
@@ -51,6 +51,11 @@ export interface LinkCount {
     readonly id: LinkTypeIri;
     readonly inCount: number;
     readonly outCount: number;
+    /**
+     * If `true`, then `inCount` and `outCount` values might be not exact
+     * in case when the values are non-zero.
+     */
+    readonly inexact?: boolean;
 }
 
 export function isEncodedBlank(iri: string): boolean {

--- a/src/data/provider.ts
+++ b/src/data/provider.ts
@@ -5,27 +5,27 @@ import {
 } from './model';
 
 /**
- * Asynchronously provides data for diagram elements, links and other diagram entities.
+ * Asynchronously provides data for the elements, links and other graph entities.
  */
 export interface DataProvider {
     readonly factory: DataFactory;
 
     /**
-     * Returns the structure of the class tree.
+     * Gets the structure and data for all known element types.
      */
     knownElementTypes(params: {
         signal?: AbortSignal;
     }): Promise<ElementTypeGraph>;
 
     /**
-     * Returns link types along with statistics.
+     * Gets the data and statistics for all known link types.
      */
     knownLinkTypes(params: {
         signal?: AbortSignal;
     }): Promise<LinkType[]>;
 
     /**
-     * Class information
+     * Gets the data for the specified element types.
      */
     elementTypes(params: {
         classIds: ReadonlyArray<ElementTypeIri>;
@@ -33,7 +33,7 @@ export interface DataProvider {
     }): Promise<Map<ElementTypeIri, ElementType>>;
 
     /**
-     * Data properties information
+     * Gets the data for the specified property types.
      */
     propertyTypes(params: {
         propertyIds: ReadonlyArray<PropertyTypeIri>;
@@ -41,7 +41,7 @@ export interface DataProvider {
     }): Promise<Map<PropertyTypeIri, PropertyType>>;
 
     /**
-     * Link type information.
+     * Gets the data for the specified link types.
      */
     linkTypes(params: {
         linkTypeIds: ReadonlyArray<LinkTypeIri>;
@@ -49,7 +49,7 @@ export interface DataProvider {
     }): Promise<Map<LinkTypeIri, LinkType>>;
 
     /**
-     * Getting the elements from the data source on diagram initialization and on navigation events
+     * Gets the data for the specified elements.
      */
     elements(params: {
         elementIds: ReadonlyArray<ElementIri>;
@@ -57,8 +57,7 @@ export interface DataProvider {
     }): Promise<Map<ElementIri, ElementModel>>;
 
     /**
-     * Should return all links between elements.
-     * linkTypeIds is ignored in current sparql providers and is subject to be removed
+     * Get all links between specified elements.
      */
     links(params: {
         elementIds: ReadonlyArray<ElementIri>;
@@ -67,30 +66,39 @@ export interface DataProvider {
     }): Promise<LinkModel[]>;
 
     /**
-     * Get link types of element to build navigation menu
+     * Gets connected link types of an element for exploration.
      */
     connectedLinkStats(params: {
         elementId: ElementIri;
+        /**
+         * Whether to allow to return inexact count of elements connected by
+         * an each link type when result is non-zero.
+         *
+         * @default false
+         */
+        inexactCount?: boolean;
         signal?: AbortSignal;
     }): Promise<LinkCount[]>;
 
     /**
      * Looks up elements with different filters:
-     *  - by type (),
-     * by element and it's connection, by full-text search.
-     * Implementation should implement all possible combinations.
+     *  - by an element type via `elementTypeId`;
+     *  - by a connected element via `refElementId`, `refElementLinkId` and `linkDirection`;
+     *  - by a text lookup via `text`;
+     *
+     * Filters can be combined to produce an intersection of the results.
      */
     lookup(params: LookupParams): Promise<LinkedElement[]>;
 }
 
 export interface LookupParams {
     /**
-     * Filter by element type.
+     * Filter by an element type.
      */
     elementTypeId?: ElementTypeIri;
     
     /**
-     * Filter by full-text search.
+     * Filter by a text lookup.
      */
     text?: string;
 

--- a/src/data/rdf/rdfDataProvider.ts
+++ b/src/data/rdf/rdfDataProvider.ts
@@ -348,6 +348,7 @@ export class RdfDataProvider implements DataProvider {
 
     connectedLinkStats(params: {
         elementId: ElementIri;
+        inexactCount?: boolean;
         signal?: AbortSignal;
     }): Promise<LinkCount[]> {
         const {elementId} = params;

--- a/src/data/sparql/sparqlModels.ts
+++ b/src/data/sparql/sparqlModels.ts
@@ -119,6 +119,11 @@ export interface LinkCountBinding {
     outCount: Rdf.Literal;
 }
 
+export interface ConnectedLinkTypeBinding {
+    link: Rdf.NamedNode;
+    direction?: Rdf.Literal;
+}
+
 export interface LinkTypeBinding {
     link: Rdf.NamedNode;
     label?: Rdf.Literal;

--- a/src/editor/overlayController.tsx
+++ b/src/editor/overlayController.tsx
@@ -57,6 +57,7 @@ export interface OpenedDialog {
     readonly target: Element | Link;
     readonly knownType: KnownDialogType | undefined;
     readonly holdSelection: boolean;
+    readonly onClose: () => void;
 }
 
 export class OverlayController {
@@ -220,6 +221,7 @@ export class OverlayController {
             target,
             knownType: dialogType,
             holdSelection,
+            onClose,
         };
 
         const dialog = (
@@ -241,9 +243,10 @@ export class OverlayController {
 
     hideDialog() {
         if (this._openedDialog) {
-            this.editor.removeTemporaryCells([this._openedDialog.target]);
             const previous = this._openedDialog;
             this._openedDialog = undefined;
+            previous.onClose();
+            this.editor.removeTemporaryCells([previous.target]);
             this.view.setCanvasWidget('dialog', null);
             this.source.trigger('changeOpenedDialog', {source: this, previous});
         }

--- a/src/widgets/connectionsMenu.tsx
+++ b/src/widgets/connectionsMenu.tsx
@@ -10,6 +10,7 @@ import { CanvasApi, CanvasContext } from '../diagram/canvasApi';
 import { defineCanvasWidget } from '../diagram/canvasWidget';
 import { changeLinkTypeVisibility } from '../diagram/commands';
 import { RichLinkType, Element } from '../diagram/elements';
+import { getContentFittingBox } from '../diagram/geometry';
 import { placeElementsAround } from '../diagram/layout';
 import { DiagramModel } from '../diagram/model';
 
@@ -25,12 +26,16 @@ import { SearchResults } from './searchResults';
 
 export interface ConnectionsMenuProps {
     commands: Events<ConnectionsMenuCommands>;
+    openAllByDefault?: boolean;
     suggestProperties?: PropertySuggestionHandler;
     instancesSearchCommands?: EventTrigger<InstancesSearchCommands>;
 }
 
 export interface ConnectionsMenuCommands {
-    show: { readonly target: Element };
+    show: {
+        readonly targets: ReadonlyArray<Element>;
+        readonly openAll?: boolean;
+    };
 }
 
 export type PropertySuggestionHandler = (params: PropertySuggestionParams) => Promise<PropertyScore[]>;
@@ -54,15 +59,28 @@ export function ConnectionsMenu(props: ConnectionsMenuProps) {
 
     React.useEffect(() => {
         const listener = new EventObserver();
-        listener.listen(commands, 'show', ({target}) => {
-            const {overlayController} = workspace;
-            const onClose = () => overlayController.hideDialog();
+        listener.listen(commands, 'show', ({targets}) => {
+            if (targets.length === 0) {
+                return;
+            }
+            const {model, overlayController} = workspace;
+
+            const virtualTarget = targets.length > 1
+                ? new VirtualTarget(targets, model, canvas)
+                : undefined;
+            const placeTarget = virtualTarget ? virtualTarget.target : targets[0];
+            const onClose = () => {
+                virtualTarget?.remove();
+                overlayController.hideDialog();
+            };
+
             overlayController.showDialog({
-                target,
+                target: placeTarget,
                 dialogType: 'connectionsMenu',
                 content: (
                     <ConnectionsMenuInner {...props}
-                        target={target}
+                        placeTarget={placeTarget}
+                        targets={targets}
                         onClose={onClose}
                         workspace={workspace}
                         canvas={canvas}
@@ -79,64 +97,140 @@ export function ConnectionsMenu(props: ConnectionsMenuProps) {
 
 defineCanvasWidget(ConnectionsMenu, element => ({element, attachment: 'viewport'}));
 
+class VirtualTarget {
+    private readonly model: DiagramModel;
+
+    readonly target: Element;
+
+    constructor(
+        elements: ReadonlyArray<Element>,
+        model: DiagramModel,
+        canvas: CanvasApi
+    ) {
+        this.model = model;
+        const target = new Element({
+            data: Element.placeholderData('' as ElementIri),
+            temporary: true,
+        });
+        this.target = target;
+
+        const elementSet = new Set(elements);
+        const updateTargetPosition = () => {
+            const {x, y, width, height} = getContentFittingBox(elements, [], canvas.renderingState);
+            target.setPosition({
+                x: x + width,
+                y: y + height / 2,
+            });
+        };
+        updateTargetPosition();
+
+        const batch = model.history.startBatch();
+        model.addElement(target);
+        batch.discard();
+    
+        const listener = new EventObserver();
+        listener.listen(model.events, 'changeCells', e => {
+            if (e.changedElement === target || e.updateAll) {
+                if (!model.elements.includes(target)) {
+                    listener.stopListening();
+                }
+            }
+        });
+        listener.listen(model.events, 'elementEvent', ({data}) => {
+            if (data.changePosition && elementSet.has(data.changePosition.source)) {
+                updateTargetPosition();
+            }
+        });
+        listener.listen(canvas.renderingState.events, 'changeElementSize', e => {
+            if (elementSet.has(e.source)) {
+                updateTargetPosition();
+            }
+        });
+    }
+
+    remove(): void {
+        if (this.model.getElement(this.target.id)) {
+            const batch = this.model.history.startBatch();
+            this.model.removeElement(this.target.id);
+            batch.discard();
+        }
+    }
+}
+
 interface ConnectionsMenuInnerProps extends ConnectionsMenuProps {
-    target: Element;
+    placeTarget: Element;
+    targets: ReadonlyArray<Element>;
     onClose: () => void;
     workspace: WorkspaceContext;
     canvas: CanvasApi;
 }
 
-interface ConnectionCount { inCount: number; outCount: number; }
-
-interface ElementOnDiagram {
-    model: ElementModel;
-    presentOnDiagram: boolean;
+interface MenuState {
+    readonly loadingState: ProgressState;
+    readonly connections?: ConnectionsData;
+    readonly objects?: ObjectsData;
+    readonly filterKey: string;
+    readonly panel: 'connections' | 'objects';
+    readonly sortMode: SortMode;
 }
 
 type SortMode = 'alphabet' | 'smart';
+
+interface ConnectionsData {
+    readonly links: ReadonlyArray<RichLinkType>;
+    readonly counts: ReadonlyMap<LinkTypeIri, ConnectionCount>;
+}
+
+interface ConnectionCount {
+    readonly inexact: boolean;
+    readonly inCount: number;
+    readonly outCount: number;
+}
+
+interface ObjectsData {
+    readonly chunk: LinkDataChunk;
+    readonly elements: ReadonlyArray<ElementOnDiagram>;
+}
 
 interface LinkDataChunk {
     /**
      * Random key to check if chunk is different from another
      * (i.e. should be re-rendered).
      */
-    chunkId: string;
-    link: RichLinkType;
-    direction?: 'in' | 'out';
-    expectedCount: number;
-    pageCount: number;
+    readonly chunkId: string;
+    readonly link: RichLinkType;
+    readonly direction?: 'in' | 'out';
+    readonly expectedCount: number | 'some';
+    readonly pageCount: number;
 }
 
-interface ObjectsData {
-    linkDataChunk: LinkDataChunk;
-    objects: ElementOnDiagram[];
+interface ElementOnDiagram {
+    readonly model: ElementModel;
+    readonly presentOnDiagram: boolean;
 }
 
 const CLASS_NAME = 'reactodia-connections-menu';
 const LINK_COUNT_PER_PAGE = 100;
 
-class ConnectionsMenuInner extends React.Component<ConnectionsMenuInnerProps> {
-    declare readonly context: never;
-
+class ConnectionsMenuInner extends React.Component<ConnectionsMenuInnerProps, MenuState> {
     private readonly ALL_RELATED_ELEMENTS_LINK: RichLinkType;
 
     private readonly handler = new EventObserver();
     private readonly linkTypesListener = new EventObserver();
-    private loadingState: ProgressState = 'none';
-
-    private links: RichLinkType[] | undefined;
-    private countMap: ReadonlyMap<LinkTypeIri, ConnectionCount> | undefined;
-
-    private linkDataChunk: LinkDataChunk | undefined;
-    private objects: ElementOnDiagram[] | undefined;
 
     constructor(props: ConnectionsMenuInnerProps) {
         super(props);
         const {workspace: {model}} = this.props;
         this.ALL_RELATED_ELEMENTS_LINK = new RichLinkType({
-            id: 'allRelatedElements' as LinkTypeIri,
+            id: 'urn:reactodia:allLinks' as LinkTypeIri,
             label: [model.factory.literal('All')],
         });
+        this.state = {
+            loadingState: 'none',
+            filterKey: '',
+            panel: 'connections',
+            sortMode: 'alphabet',
+        };
     }
 
     private updateAll = () => this.forceUpdate();
@@ -153,226 +247,147 @@ class ConnectionsMenuInner extends React.Component<ConnectionsMenuInnerProps> {
         this.linkTypesListener.stopListening();
     }
 
-    private resubscribeOnLinkTypeEvents(linkTypesOfElement: ReadonlyArray<RichLinkType>) {
-        this.linkTypesListener.stopListening();
-        for (const linkType of linkTypesOfElement) {
-            this.linkTypesListener.listen(linkType.events, 'changeLabel', this.updateAll);
-            this.linkTypesListener.listen(linkType.events, 'changeVisibility', this.updateAll);
-        }
-    }
+    private async loadLinks() {
+        const {targets, workspace: {model, triggerWorkspaceEvent}} = this.props;
 
-    private loadLinks() {
-        const {target, workspace: {model, triggerWorkspaceEvent}} = this.props;
+        this.setState({
+            loadingState: 'loading',
+            connections: {
+                links: [],
+                counts: new Map(),
+            },
+        });
 
-        this.loadingState = 'loading';
-        this.links = [];
-        this.countMap = new Map();
-        model.dataProvider.connectedLinkStats({elementId: target.iri})
-            .then(linkTypes => {
-                this.loadingState = 'completed';
-
-                const countMap = new Map<LinkTypeIri, ConnectionCount>();
-                const links: RichLinkType[] = [];
-                for (const {id: linkTypeId, inCount, outCount} of linkTypes) {
-                    countMap.set(linkTypeId, {inCount, outCount});
-                    links.push(model.createLinkType(linkTypeId));
-                }
-
-                countMap.set(
-                    this.ALL_RELATED_ELEMENTS_LINK.id,
-                    Array.from(countMap.values())
-                        .reduce(
-                            (a, b) => ({
-                                inCount: a.inCount + b.inCount,
-                                outCount: a.outCount + b.outCount,
-                            }),
-                            {inCount: 0, outCount: 0}
-                        )
-                );
-
-                this.countMap = countMap;
-                this.links = links;
-                this.resubscribeOnLinkTypeEvents(this.links);
-
-                this.updateAll();
-
-                triggerWorkspaceEvent(WorkspaceEventKey.connectionsLoadLinks);
-            })
-            .catch(err => {
-                console.error(err);
-                this.loadingState = 'error';
-                this.updateAll();
-            });
-        this.updateAll();
-    }
-
-    private loadObjects(linkDataChunk: LinkDataChunk) {
-        const {target, workspace: {model, triggerWorkspaceEvent}} = this.props;
-        const {link, direction, pageCount} = linkDataChunk;
-
-        this.loadingState = 'loading';
-        this.linkDataChunk = linkDataChunk;
-        this.objects = [];
-
-        model.dataProvider.lookup({
-            refElementId: target.iri,
-            refElementLinkId: link === this.ALL_RELATED_ELEMENTS_LINK ? undefined : link.id,
-            linkDirection: direction,
-            limit: pageCount * LINK_COUNT_PER_PAGE,
-        }).then(elements => {
-            this.loadingState = 'completed';
-            const presentOnDiagramIris = new Set(model.elements.map(el => el.iri));
-            this.objects = elements.map(linked => ({
-                model: linked.element,
-                presentOnDiagram: presentOnDiagramIris.has(linked.element.id),
-            }));
-            this.updateAll();
-
-            triggerWorkspaceEvent(WorkspaceEventKey.connectionsLoadElements);
-        }).catch(err => {
+        const requestInexact = targets.length > 1;
+        const counts = new Map<LinkTypeIri, ConnectionCount>();
+        try {
+            await Promise.all(targets.map(target =>
+                model.dataProvider
+                    .connectedLinkStats({elementId: target.iri, inexactCount: requestInexact})
+                    .then(linkTypes => {
+                        for (const {id: linkTypeId, inCount, outCount, inexact} of linkTypes) {
+                            const previous: ConnectionCount = counts.get(linkTypeId)
+                                ?? {inCount: 0, outCount: 0, inexact: false};
+                            counts.set(linkTypeId, {
+                                inexact: Boolean(requestInexact || previous.inexact || inexact),
+                                inCount: previous.inCount + inCount,
+                                outCount: previous.outCount + outCount,
+                            });
+                        }
+                    })
+            ));
+        } catch (err) {
             console.error(err);
-            this.loadingState = 'error';
-            this.updateAll();
+            this.setState({loadingState: 'error'});
+            return;
+        }
+
+        const links = Array.from(
+            counts.keys(),
+            linkTypeId => model.createLinkType(linkTypeId)
+        );
+        counts.set(
+            this.ALL_RELATED_ELEMENTS_LINK.id,
+            Array.from(counts.values())
+                .reduce<ConnectionCount>(
+                    (a, b) => ({
+                        inexact: Boolean(a.inexact || b.inexact),
+                        inCount: a.inCount + b.inCount,
+                        outCount: a.outCount + b.outCount,
+                    }),
+                    {inCount: 0, outCount: 0, inexact: false}
+                )
+        );
+
+        this.setState({
+            loadingState: 'completed',
+            connections: {links, counts},
+        }, () => {
+            this.resubscribeOnLinkTypeEvents();
+            triggerWorkspaceEvent(WorkspaceEventKey.connectionsLoadLinks);
         });
     }
 
-    private addSelectedElements = (selectedObjects: ElementOnDiagram[]) => {
-        const {onClose} = this.props;
+    private resubscribeOnLinkTypeEvents() {
+        const {connections} = this.state;
+        this.linkTypesListener.stopListening();
+        if (connections) {
+            for (const linkType of connections.links) {
+                this.linkTypesListener.listen(linkType.events, 'changeLabel', this.updateAll);
+                this.linkTypesListener.listen(linkType.events, 'changeVisibility', this.updateAll);
+            }
+        }
+    }
 
-        const addedElementsIris = selectedObjects.map(item => item.model.id);
-        const linkType = this.linkDataChunk ? this.linkDataChunk.link : undefined;
-        const hasChosenLinkType = this.linkDataChunk && linkType !== this.ALL_RELATED_ELEMENTS_LINK;
+    private async loadObjects(chunk: LinkDataChunk) {
+        const {targets, workspace: {model, triggerWorkspaceEvent}} = this.props;
+        const {link, direction, pageCount} = chunk;
 
-        this.onAddElements(addedElementsIris, hasChosenLinkType ? linkType : undefined);
-        onClose();
-    };
-
-    private onAddElements = (elementIris: ElementIri[], linkType: RichLinkType | undefined) => {
-        const {target, workspace: {model, triggerWorkspaceEvent}, canvas} = this.props;
-        const batch = model.history.startBatch('Add connected elements');
-
-        const elements = elementIris.map(iri => model.createElement(iri));
-        canvas.renderingState.syncUpdate();
-
-        placeElementsAround({
-            elements,
-            model,
-            sizeProvider: canvas.renderingState,
-            targetElement: target,
-            preferredLinksLength: 300,
+        this.setState({
+            loadingState: 'loading',
+            objects: {chunk, elements: []},
         });
 
-        if (linkType && linkType.visibility === 'hidden') {
-            batch.history.execute(changeLinkTypeVisibility(linkType, 'visible'));
-        }
-
-        batch.history.execute(requestElementData(model, elementIris));
-        batch.history.execute(restoreLinksBetweenElements(model));
-        batch.store();
-
-        triggerWorkspaceEvent(WorkspaceEventKey.editorAddElements);
-    };
-
-    private onExpandLink = (linkDataChunk: LinkDataChunk) => {
-        const {workspace: {triggerWorkspaceEvent}} = this.props;
-        const alreadyLoaded = (
-            this.objects &&
-            this.linkDataChunk &&
-            this.linkDataChunk.link === linkDataChunk.link &&
-            this.linkDataChunk.direction === linkDataChunk.direction
-        );
-        if (!alreadyLoaded) {
-            this.loadObjects(linkDataChunk);
-        }
-        this.updateAll();
-
-        triggerWorkspaceEvent(WorkspaceEventKey.connectionsExpandLink);
-    };
-
-    private onMoveToFilter = (linkDataChunk: LinkDataChunk) => {
-        const {target, instancesSearchCommands, workspace: {model}} = this.props;
-        const {link, direction} = linkDataChunk;
-
-        if (link === this.ALL_RELATED_ELEMENTS_LINK) {
-            instancesSearchCommands?.trigger('setCriteria', {
-                criteria: {refElement: target},
-            });
-        } else {
-            const selectedElement = model.getElement(target.id)!;
-            instancesSearchCommands?.trigger('setCriteria', {
-                criteria: {
-                    refElement: selectedElement,
-                    refElementLink: link,
+        const loadedElements = new Map<ElementIri, ElementModel>();
+        try {
+            await Promise.all(targets.map(target =>
+                model.dataProvider.lookup({
+                    refElementId: target.iri,
+                    refElementLinkId: link === this.ALL_RELATED_ELEMENTS_LINK ? undefined : link.id,
                     linkDirection: direction,
-                },
-            });
+                    limit: pageCount * LINK_COUNT_PER_PAGE,
+                }).then(linkedElements => {
+                    for (const {element} of linkedElements) {
+                        loadedElements.set(element.id, element);
+                    }
+                })
+            ));
+        } catch (err) {
+            console.error(err);
+            this.setState({loadingState: 'error'});
+            return;
         }
-    };
+
+        const presentOnDiagramIris = new Set(model.elements.map(el => el.iri));
+        const elements = Array.from(loadedElements.values(), element => ({
+            model: element,
+            presentOnDiagram: presentOnDiagramIris.has(element.id),
+        }));
+
+        this.setState({
+            loadingState: 'completed',
+            objects: {chunk, elements},
+        }, () => {
+            triggerWorkspaceEvent(WorkspaceEventKey.connectionsLoadElements);
+        });
+    }
 
     render() {
-        const {target, suggestProperties, instancesSearchCommands, workspace: {model}} = this.props;
-
-        const connectionsData: ConnectionsData = {
-            links: this.links ?? [],
-            countMap: this.countMap ?? new Map(),
-        };
-
-        let objectsData: ObjectsData | undefined;
-        if (this.linkDataChunk && this.objects) {
-            objectsData = {
-                linkDataChunk: this.linkDataChunk,
-                objects: this.objects,
-            };
-        }
-        
+        const {loadingState, filterKey} = this.state;
         return (
-            <MenuMarkup
-                target={target}
-                connectionsData={connectionsData}
-                objectsData={objectsData}
-                state={this.loadingState}
-                model={model}
-                allRelatedLink={this.ALL_RELATED_ELEMENTS_LINK}
-                onExpandLink={this.onExpandLink}
-                onPressAddSelected={this.addSelectedElements}
-                onMoveToFilter={instancesSearchCommands ? this.onMoveToFilter : undefined}
-                propertySuggestionCall={suggestProperties}
-            />
+            <div className={CLASS_NAME}>
+                <span id='reactodia-dialog-caption'
+                    className={`reactodia-label ${CLASS_NAME}__title-label`}>
+                    {this.getTitle()}
+                </span>
+                {this.getBreadCrumbs()}
+                <div className={`${CLASS_NAME}__search-line`}>
+                    <input type='text'
+                        className={`search-input reactodia-form-control ${CLASS_NAME}__search-line-input`}
+                        name='reactodia-connection-menu-filter'
+                        value={filterKey}
+                        onChange={this.onChangeFilter}
+                        placeholder='Search for...'
+                    />
+                    {this.renderSortSwitches()}
+                </div>
+                <ProgressBar state={loadingState}
+                    title='Loading element connections'
+                    height={10}
+                />
+                {this.getBody()}
+            </div>
         );
-    }
-}
-
-interface MenuMarkupProps {
-    target: Element;
-
-    connectionsData: ConnectionsData;
-    objectsData?: ObjectsData;
-
-    model: DiagramModel;
-    state: ProgressState;
-    allRelatedLink: RichLinkType;
-
-    onExpandLink: (linkDataChunk: LinkDataChunk) => void;
-    onPressAddSelected: (selectedObjects: ElementOnDiagram[]) => void;
-    onMoveToFilter: ((linkDataChunk: LinkDataChunk) => void) | undefined;
-
-    propertySuggestionCall?: PropertySuggestionHandler;
-}
-
-interface MenuMarkupState {
-    filterKey: string;
-    panel: string;
-    sortMode: SortMode;
-}
-
-class MenuMarkup extends React.Component<MenuMarkupProps, MenuMarkupState> {
-    constructor(props: MenuMarkupProps) {
-        super(props);
-        this.state = {
-            filterKey: '',
-            panel: 'connections',
-            sortMode: 'alphabet',
-        };
     }
 
     private onChangeFilter = (e: React.FormEvent<HTMLInputElement>) => {
@@ -381,27 +396,21 @@ class MenuMarkup extends React.Component<MenuMarkupProps, MenuMarkupState> {
     };
 
     private getTitle() {
-        if (this.props.objectsData && this.state.panel === 'objects') {
+        const {connections, objects, panel} = this.state;
+        if (objects && panel === 'objects') {
             return 'Objects';
-        } else if (this.props.connectionsData && this.state.panel === 'connections') {
+        } else if (connections && panel === 'connections') {
             return 'Connections';
         }
         return 'Error';
     }
 
-    private onExpandLink = (linkDataChunk: LinkDataChunk) => {
-        this.setState({ filterKey: '',  panel: 'objects' });
-        this.props.onExpandLink(linkDataChunk);
-    };
-
-    private onCollapseLink = () => {
-        this.setState({ filterKey: '',  panel: 'connections' });
-    };
-
     private getBreadCrumbs() {
-        if (this.props.objectsData && this.state.panel === 'objects') {
-            const {link, direction} = this.props.objectsData.linkDataChunk;
-            const localizedText = this.props.model.locale.formatLabel(link.label, link.id);
+        const {workspace: {model}} = this.props;
+        const {objects, panel} = this.state;
+        if (objects && panel === 'objects') {
+            const {link, direction} = objects.chunk;
+            const localizedText = model.locale.formatLabel(link.label, link.id);
 
             return <span className={`${CLASS_NAME}__breadcrumbs`}>
                 <a className={`${CLASS_NAME}__breadcrumbs-link`}
@@ -414,34 +423,65 @@ class MenuMarkup extends React.Component<MenuMarkupProps, MenuMarkupState> {
         }
     }
 
+    private onExpandLink = (chunk: LinkDataChunk) => {
+        const {workspace: {triggerWorkspaceEvent}} = this.props;
+        const {objects} = this.state;
+
+        this.setState({filterKey: '',  panel: 'objects'});
+        const alreadyLoaded = (
+            objects &&
+            objects.chunk.link === chunk.link &&
+            objects.chunk.direction === chunk.direction
+        );
+        if (!alreadyLoaded) {
+            this.loadObjects(chunk);
+        }
+
+        triggerWorkspaceEvent(WorkspaceEventKey.connectionsExpandLink);
+    };
+
+    private onCollapseLink = () => {
+        this.setState({filterKey: '',  panel: 'connections'});
+    };
+
     private getBody() {
-        if (this.props.state === 'error') {
+        const {
+            targets, suggestProperties,instancesSearchCommands, workspace: {model},
+        } = this.props;
+        const {loadingState, objects, connections, filterKey, panel, sortMode} = this.state;
+
+        if (loadingState === 'error') {
             return <label className={`reactodia-label ${CLASS_NAME}__error`}>Error</label>;
-        } else if (this.props.objectsData && this.state.panel === 'objects') {
-            return <ObjectsPanel
-                data={this.props.objectsData}
-                onMoveToFilter={this.props.onMoveToFilter}
-                model={this.props.model}
-                filterKey={this.state.filterKey}
-                loading={this.props.state === 'loading'}
-                onPressAddSelected={this.props.onPressAddSelected}
-            />;
-        } else if (this.props.connectionsData && this.state.panel === 'connections') {
-            if (this.props.state === 'loading') {
+        } else if (objects && panel === 'objects') {
+            return (
+                <ObjectsPanel
+                    data={objects}
+                    onMoveToFilter={this.onMoveToFilter}
+                    model={model}
+                    filterKey={filterKey}
+                    loading={loadingState === 'loading'}
+                    onPressAddSelected={this.onAddSelectedElements}
+                />
+            );
+        } else if (connections && panel === 'connections') {
+            if (loadingState === 'loading') {
                 return <label className={`reactodia-label ${CLASS_NAME}__loading`}>Loading...</label>;
             }
-
             return (
                 <ConnectionsList
-                    id={this.props.target.id}
-                    data={this.props.connectionsData}
-                    model={this.props.model}
-                    filterKey={this.state.filterKey}
-                    allRelatedLink={this.props.allRelatedLink}
+                    targets={targets}
+                    data={connections}
+                    model={model}
+                    filterKey={filterKey}
+                    allRelatedLink={this.ALL_RELATED_ELEMENTS_LINK}
                     onExpandLink={this.onExpandLink}
-                    onMoveToFilter={this.props.onMoveToFilter}
-                    propertySuggestionCall={this.props.propertySuggestionCall}
-                    sortMode={this.state.sortMode}
+                    onMoveToFilter={
+                        instancesSearchCommands && targets.length === 1
+                            ? this.onMoveToFilter
+                            : undefined
+                    }
+                    propertySuggestionCall={suggestProperties}
+                    sortMode={sortMode}
                 />
             );
         } else {
@@ -449,13 +489,82 @@ class MenuMarkup extends React.Component<MenuMarkupProps, MenuMarkupState> {
         }
     }
 
-    private onSortChange = (e: React.FormEvent<HTMLInputElement>) => {
-        const value = (e.target as HTMLInputElement).value as SortMode;
+    private onAddSelectedElements = (selectedObjects: ElementOnDiagram[]) => {
+        const {onClose} = this.props;
+        const {objects} = this.state;
 
-        if (this.state.sortMode === value) { return; }
+        const addedElementsIris = selectedObjects.map(item => item.model.id);
+        const linkType = objects ? objects.chunk.link : undefined;
+        const hasChosenLinkType = objects && linkType !== this.ALL_RELATED_ELEMENTS_LINK;
 
-        this.setState({sortMode: value});
+        this.placeElements(addedElementsIris, hasChosenLinkType ? linkType : undefined);
+        onClose();
     };
+
+    private placeElements(elementIris: ElementIri[], linkType: RichLinkType | undefined) {
+        const {placeTarget, workspace: {model, triggerWorkspaceEvent}, canvas} = this.props;
+        const batch = model.history.startBatch('Add connected elements');
+
+        const elements = elementIris.map(iri => model.createElement(iri));
+        canvas.renderingState.syncUpdate();
+
+        placeElementsAround({
+            elements,
+            model,
+            sizeProvider: canvas.renderingState,
+            targetElement: placeTarget,
+            preferredLinksLength: 300,
+        });
+
+        if (linkType && linkType.visibility === 'hidden') {
+            batch.history.execute(changeLinkTypeVisibility(linkType, 'visible'));
+        }
+
+        batch.history.execute(requestElementData(model, elementIris));
+        batch.history.execute(restoreLinksBetweenElements(model));
+        batch.store();
+
+        triggerWorkspaceEvent(WorkspaceEventKey.editorAddElements);
+    }
+
+    private onMoveToFilter = (linkDataChunk: LinkDataChunk) => {
+        const {targets, instancesSearchCommands, workspace: {model}} = this.props;
+        const {link, direction} = linkDataChunk;
+
+        const singleTarget = targets.length === 1 ? targets[0] : undefined;
+        if (!singleTarget) {
+            return;
+        }
+        
+        if (link === this.ALL_RELATED_ELEMENTS_LINK) {
+            instancesSearchCommands?.trigger('setCriteria', {
+                criteria: {refElement: singleTarget},
+            });
+        } else {
+            const selectedElement = model.getElement(singleTarget.id)!;
+            instancesSearchCommands?.trigger('setCriteria', {
+                criteria: {
+                    refElement: selectedElement,
+                    refElementLink: link,
+                    linkDirection: direction,
+                },
+            });
+        }
+    };
+
+    private renderSortSwitches() {
+        const {suggestProperties} = this.props;
+        const {panel} = this.state;
+        if (!(panel === 'connections' && suggestProperties)) {
+            return null;
+        }
+        return (
+            <div className={`${CLASS_NAME}__sort-switches`}>
+                {this.renderSortSwitch('alphabet', `${CLASS_NAME}__sort-label-alpha`, 'Sort alphabetically')}
+                {this.renderSortSwitch('smart', `${CLASS_NAME}__sort-label-smart`, 'Smart sort')}
+            </div>
+        );
+    }
 
     private renderSortSwitch(id: string, labelClass: string, title: string) {
         return (
@@ -476,62 +585,27 @@ class MenuMarkup extends React.Component<MenuMarkupProps, MenuMarkupState> {
         );
     }
 
-    private renderSortSwitches() {
-        if (this.state.panel !== 'connections' || !this.props.propertySuggestionCall) { return null; }
+    private onSortChange = (e: React.FormEvent<HTMLInputElement>) => {
+        const value = (e.target as HTMLInputElement).value as SortMode;
 
-        return (
-            <div className={`${CLASS_NAME}__sort-switches`}>
-                {this.renderSortSwitch('alphabet', `${CLASS_NAME}__sort-label-alpha`, 'Sort alphabetically')}
-                {this.renderSortSwitch('smart', `${CLASS_NAME}__sort-label-smart`, 'Smart sort')}
-            </div>
-        );
-    }
+        if (this.state.sortMode === value) { return; }
 
-    render() {
-        return (
-            <div className={CLASS_NAME}>
-                <span id='reactodia-dialog-caption'
-                    className={`reactodia-label ${CLASS_NAME}__title-label`}>
-                    {this.getTitle()}
-                </span>
-                {this.getBreadCrumbs()}
-                <div className={`${CLASS_NAME}__search-line`}>
-                    <input type='text'
-                        className={`search-input reactodia-form-control ${CLASS_NAME}__search-line-input`}
-                        name='reactodia-connection-menu-filter'
-                        value={this.state.filterKey}
-                        onChange={this.onChangeFilter}
-                        placeholder='Search for...'
-                    />
-                    {this.renderSortSwitches()}
-                </div>
-                <ProgressBar state={this.props.state}
-                    title='Loading element connections'
-                    height={10}
-                />
-                {this.getBody()}
-            </div>
-        );
-    }
+        this.setState({sortMode: value});
+    };
 }
 
 interface ConnectionsListProps {
-    id: string;
+    targets: ReadonlyArray<Element>;
     data: ConnectionsData;
     model: DiagramModel;
     filterKey: string;
 
     allRelatedLink: RichLinkType;
-    onExpandLink: (linkDataChunk: LinkDataChunk) => void;
-    onMoveToFilter: ((linkDataChunk: LinkDataChunk) => void) | undefined;
+    onExpandLink: (chunk: LinkDataChunk) => void;
+    onMoveToFilter: ((chunk: LinkDataChunk) => void) | undefined;
 
     propertySuggestionCall?: PropertySuggestionHandler;
     sortMode: SortMode;
-}
-
-interface ConnectionsData {
-    readonly links: ReadonlyArray<RichLinkType>;
-    readonly countMap: ReadonlyMap<LinkTypeIri, ConnectionCount>;
 }
 
 interface ConnectionsListState {
@@ -563,8 +637,13 @@ class ConnectionsList extends React.Component<ConnectionsListProps, ConnectionsL
     }
 
     private tryUpdateScores() {
-        const {propertySuggestionCall, filterKey, sortMode, id, data, model} = this.props;
-        if (propertySuggestionCall && (filterKey || sortMode === 'smart')) {
+        const {propertySuggestionCall, filterKey, sortMode, targets, data, model} = this.props;
+        if (
+            propertySuggestionCall &&
+            (filterKey || sortMode === 'smart') &&
+            targets.length === 1
+        ) {
+            const singleTarget = targets[0];
             const lang = model.language;
             const token = filterKey.trim();
             const properties = data.links.map(l => l.id);
@@ -573,7 +652,7 @@ class ConnectionsList extends React.Component<ConnectionsListProps, ConnectionsL
             this.suggestionCancellation = new AbortController();
             const signal = this.suggestionCancellation.signal;
     
-            propertySuggestionCall({elementId: id, token, properties, lang, signal})
+            propertySuggestionCall({elementId: singleTarget.id, token, properties, lang, signal})
                 .then(scoreList => {
                     const scores = new Map<LinkTypeIri, PropertyScore>();
                     for (const score of scoreList) {
@@ -635,16 +714,15 @@ class ConnectionsList extends React.Component<ConnectionsListProps, ConnectionsL
     private getViews = (links: RichLinkType[], notSure?: boolean) => {
         const {model, data} = this.props;
         const {scores} = this.state;
-        const countMap = data.countMap ?? {};
 
         const views: JSX.Element[] = [];
         const addView = (link: RichLinkType, direction: 'in' | 'out') => {
-            const count = (
-                direction === 'in'
-                    ? countMap.get(link.id)?.inCount
-                    : countMap.get(link.id)?.outCount
-            ) ?? 0;
-
+            const {inCount, outCount, inexact} = data.counts.get(link.id) ?? {
+                inCount: 0,
+                outCount: 0,
+                inexact: false,
+            };
+            const count = direction === 'in' ? inCount : outCount;
             if (count === 0) {
                 return;
             }
@@ -656,7 +734,7 @@ class ConnectionsList extends React.Component<ConnectionsListProps, ConnectionsL
                     link={link}
                     onExpandLink={this.props.onExpandLink}
                     model={model}
-                    count={count}
+                    count={inexact && count > 0 ? 'some' : count}
                     direction={direction}
                     filterKey={notSure ? '' : this.props.filterKey}
                     onMoveToFilter={this.props.onMoveToFilter}
@@ -690,15 +768,16 @@ class ConnectionsList extends React.Component<ConnectionsListProps, ConnectionsL
         } else {
             viewList = views;
             if (views.length > 1 || (isSmartMode && probableViews.length > 1)) {
-                const countMap = this.props.data.countMap;
-                const allRelatedElements = countMap.get(allRelatedLink.id)!;
+                const countMap = this.props.data.counts;
+                const {inCount, outCount, inexact} = countMap.get(allRelatedLink.id)!;
+                const totalCount = inCount + outCount;
                 viewList = [
                     <LinkInPopupMenu
                         key={allRelatedLink.id}
                         link={allRelatedLink}
                         onExpandLink={this.props.onExpandLink}
                         model={model}
-                        count={allRelatedElements.inCount + allRelatedElements.outCount}
+                        count={inexact && totalCount > 0 ? 'some' : totalCount}
                         onMoveToFilter={this.props.onMoveToFilter}
                     />,
                     <hr key='reactodia-hr-line' className={`${CLASS_NAME}__links-list-hr`} />,
@@ -730,7 +809,7 @@ class ConnectionsList extends React.Component<ConnectionsListProps, ConnectionsL
 
 interface LinkInPopupMenuProps {
     link: RichLinkType;
-    count: number;
+    count: number | 'some';
     direction?: 'in' | 'out';
     model: DiagramModel;
     filterKey?: string;
@@ -740,32 +819,6 @@ interface LinkInPopupMenuProps {
 }
 
 class LinkInPopupMenu extends React.Component<LinkInPopupMenuProps> {
-    constructor(props: LinkInPopupMenuProps) {
-        super(props);
-    }
-
-    private onExpandLink(expectedCount: number, direction?: 'in' | 'out') {
-        this.props.onExpandLink({
-            chunkId: generate128BitID(),
-            link: this.props.link,
-            direction,
-            expectedCount,
-            pageCount: 1,
-        });
-    }
-
-    private onMoveToFilter = (evt: React.MouseEvent<any>) => {
-        evt.stopPropagation();
-        const {onMoveToFilter} = this.props;
-        onMoveToFilter?.({
-            chunkId: generate128BitID(),
-            link: this.props.link,
-            direction: this.props.direction,
-            expectedCount: this.props.count,
-            pageCount: 1,
-        });
-    };
-
     render() {
         const {model, link, filterKey, direction, count, probability = 0} = this.props;
         const fullText = model.locale.formatLabel(link.label, link.id);
@@ -783,7 +836,7 @@ class LinkInPopupMenu extends React.Component<LinkInPopupMenuProps> {
             <li data-linktypeid={link.id}
                 className={`${CLASS_NAME}__link`}
                 title={`${directionName} of "${fullText}" ${model.locale.formatIri(link.id)}`}
-                onClick={() => this.onExpandLink(count, direction)}>
+                onClick={() => this.onExpandLink()}>
                 {direction === 'in' || direction === 'out' ? (
                     <div className={`${CLASS_NAME}__link-direction`}>
                         {direction === 'in' && <div className={`${CLASS_NAME}__link-direction-in`} />}
@@ -791,9 +844,11 @@ class LinkInPopupMenu extends React.Component<LinkInPopupMenuProps> {
                     </div>
                 ) : null}
                 <div className={`${CLASS_NAME}__link-title`}>{textLine}</div>
-                <span className={`reactodia-badge ${CLASS_NAME}__link-count`}>
-                    {count <= LINK_COUNT_PER_PAGE ? count : '100+'}
-                </span>
+                {count === 'some' ? null : (
+                    <span className={`reactodia-badge ${CLASS_NAME}__link-count`}>
+                        {count <= LINK_COUNT_PER_PAGE ? count : '100+'}
+                    </span>
+                )}
                 {this.props.onMoveToFilter ? (
                     <div className={`${CLASS_NAME}__link-filter-button`}
                         onClick={this.onMoveToFilter}
@@ -805,6 +860,29 @@ class LinkInPopupMenu extends React.Component<LinkInPopupMenuProps> {
             </li>
         );
     }
+
+    private onExpandLink() {
+        const {count, direction} = this.props;
+        this.props.onExpandLink({
+            chunkId: generate128BitID(),
+            link: this.props.link,
+            direction,
+            expectedCount: count,
+            pageCount: 1,
+        });
+    }
+
+    private onMoveToFilter = (evt: React.MouseEvent<any>) => {
+        evt.stopPropagation();
+        const {link, count, direction, onMoveToFilter} = this.props;
+        onMoveToFilter?.({
+            chunkId: generate128BitID(),
+            link,
+            direction,
+            expectedCount: count,
+            pageCount: 1,
+        });
+    };
 }
 
 interface ObjectsPanelProps {
@@ -831,7 +909,7 @@ class ObjectsPanel extends React.Component<ObjectsPanelProps, ObjectsPanelState>
         props: ObjectsPanelProps,
         state: ObjectsPanelState | undefined
     ): ObjectsPanelState | null {
-        if (state && state.chunkId === props.data.linkDataChunk.chunkId) {
+        if (state && state.chunkId === props.data.chunk.chunkId) {
             return null;
         }
         return ObjectsPanel.makeStateFromProps(props);
@@ -839,27 +917,27 @@ class ObjectsPanel extends React.Component<ObjectsPanelProps, ObjectsPanelState>
 
     static makeStateFromProps(props: ObjectsPanelProps): ObjectsPanelState {
         return {
-            chunkId: props.data.linkDataChunk.chunkId,
+            chunkId: props.data.chunk.chunkId,
             selection: new Set<ElementIri>(),
         };
     }
 
     private onSelectAll = () => {
-        const objects = this.props.data.objects;
+        const objects = this.props.data.elements;
         if (objects.length === 0) { return; }
         const allSelected = allNonPresentedAreSelected(objects, this.state.selection);
         const newSelection = allSelected
             ? new Set<ElementIri>()
-            : selectNonPresented(this.props.data.objects);
+            : selectNonPresented(this.props.data.elements);
         this.updateSelection(newSelection);
     };
 
-    private getFilteredObjects(): ElementOnDiagram[] {
+    private getFilteredObjects(): ReadonlyArray<ElementOnDiagram> {
         if (!this.props.filterKey) {
-            return this.props.data.objects;
+            return this.props.data.elements;
         }
         const filterKey = this.props.filterKey.toLowerCase();
-        return this.props.data.objects.filter(element => {
+        return this.props.data.elements.filter(element => {
             const text = this.props.model.locale.formatLabel(
                 element.model.label, element.model.id
             ).toLowerCase();
@@ -883,27 +961,40 @@ class ObjectsPanel extends React.Component<ObjectsPanelProps, ObjectsPanelState>
     };
 
     private renderCounter(activeObjCount: number) {
-        const countString = `${activeObjCount}\u00A0of\u00A0${this.props.data.objects.length}`;
+        const {data: {chunk, elements}} = this.props;
+        const countString = `${activeObjCount}\u00A0of\u00A0${elements.length}`;
 
-        const wrongNodes =
-            Math.min(LINK_COUNT_PER_PAGE, this.props.data.linkDataChunk.expectedCount) - this.props.data.objects.length;
-        const wrongNodesString = Math.abs(wrongNodes) > LINK_COUNT_PER_PAGE ?
-            `${LINK_COUNT_PER_PAGE}+` : Math.abs(wrongNodes).toString();
-        const wrongNodesCount = wrongNodes === 0 ? '' : (wrongNodes < 0 ?
-            `\u00A0(${wrongNodesString})` : `\u00A0(${wrongNodesString})`);
-        const wrongNodesTitle = wrongNodes === 0 ? '' : (wrongNodes > 0 ? 'Unavailable nodes' : 'Extra nodes');
+        let extraCountInfo: JSX.Element | null = null;
+        if (chunk.expectedCount !== 'some') {
+            const wrongNodes =
+                Math.min(LINK_COUNT_PER_PAGE, chunk.expectedCount) - elements.length;
+            const wrongNodesString = Math.abs(wrongNodes) > LINK_COUNT_PER_PAGE ?
+                `${LINK_COUNT_PER_PAGE}+` : Math.abs(wrongNodes).toString();
+            extraCountInfo = (
+                <span className={`${CLASS_NAME}__objects-extra`}
+                    title={wrongNodes === 0
+                        ? undefined
+                        : (wrongNodes > 0 ? 'Unavailable nodes' : 'Extra nodes')
+                    }>
+                    {wrongNodes === 0 ? null : (
+                        wrongNodes < 0
+                            ? `\u00A0(${wrongNodesString})`
+                            : `\u00A0(${wrongNodesString})`
+                    )}
+                </span>
+            );
+        }
 
-        return <div className={`reactodia-label ${CLASS_NAME}__objects-count`}>
-            <span>{countString}</span>
-            <span className={`${CLASS_NAME}__objects-extra`}
-                title={wrongNodesTitle}>
-                {wrongNodesCount}
-            </span>
-        </div>;
+        return (
+            <div className={`reactodia-label ${CLASS_NAME}__objects-count`}>
+                <span>{countString}</span>
+                {extraCountInfo}
+            </div>
+        );
     }
 
     render() {
-        const {onPressAddSelected, filterKey, onMoveToFilter} = this.props;
+        const {data, filterKey, onPressAddSelected, onMoveToFilter} = this.props;
         const {selection} = this.state;
         const objects = this.getFilteredObjects();
         const isAllSelected = allNonPresentedAreSelected(objects, selection);
@@ -934,10 +1025,10 @@ class ObjectsPanel extends React.Component<ObjectsPanelProps, ObjectsPanelState>
                         onSelectionChanged={this.updateSelection}
                         highlightText={filterKey}
                     />
-                    {this.props.data.linkDataChunk.expectedCount > LINK_COUNT_PER_PAGE ? (
+                    {data.chunk.expectedCount !== 'some' && data.chunk.expectedCount > LINK_COUNT_PER_PAGE ? (
                         onMoveToFilter ? (
                             <div className={`${CLASS_NAME}__move-to-filter`}
-                                onClick={() => onMoveToFilter(this.props.data.linkDataChunk)}>
+                                onClick={() => onMoveToFilter(data.chunk)}>
                                 The list was truncated, for more data click here to use the filter panel
                             </div>
                         ) : (

--- a/src/widgets/selection.tsx
+++ b/src/widgets/selection.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { shallowArrayEqual } from '../coreUtils/collections';
-import { EventObserver } from '../coreUtils/events';
+import { EventObserver, EventTrigger } from '../coreUtils/events';
 import {
     SyncStore, useEventStore, useFrameDebouncedStore, useSyncStore,
 } from '../coreUtils/hooks';
@@ -18,9 +18,10 @@ import { EditorController, SelectionItem } from '../editor/editorController';
 
 import { WorkspaceContext } from '../workspace/workspaceContext';
 
+import type { ConnectionsMenuCommands } from './connectionsMenu';
 import {
     SelectionActionRemove, SelectionActionZoomToFit, SelectionActionLayout,
-    SelectionActionExpand,
+    SelectionActionExpand, SelectionActionConnections,
 } from './selectionAction';
 
 export interface SelectionProps {
@@ -32,6 +33,7 @@ export interface SelectionProps {
      * @default 2
      */
     itemMargin?: number;
+    connectionsMenuCommands?: EventTrigger<ConnectionsMenuCommands>;
     /**
      * `SelectionAction` items representing available actions on the selected elements.
      *
@@ -193,6 +195,7 @@ function SelectionBox(props: SelectionBoxProps) {
         model, canvas, editor, selectedElements, highlightedBox,
         boxMargin = 5,
         itemMargin = 2,
+        connectionsMenuCommands,
         children,
     } = props;
 
@@ -238,6 +241,10 @@ function SelectionBox(props: SelectionBoxProps) {
                         <SelectionActionRemove dock='ne' dockRow={1} />
                         <SelectionActionZoomToFit dock='ne' dockRow={2} />
                         <SelectionActionLayout dock='ne' dockRow={3} />
+                        <SelectionActionConnections dock='ne'
+                            dockRow={4}
+                            commands={connectionsMenuCommands}
+                        />
                         <SelectionActionExpand dock='s' />
                     </>}
                 </div>

--- a/src/widgets/selectionAction.tsx
+++ b/src/widgets/selectionAction.tsx
@@ -269,14 +269,12 @@ export function SelectionActionConnections(props: SelectionActionConnectionsProp
     const {className, title, commands, ...otherProps} = props;
     const {editor, overlayController} = React.useContext(WorkspaceContext)!;
     const elements = editor.selection.filter((cell): cell is Element => cell instanceof Element);
-    if (!(commands && elements.length === 1)) {
+    if (!commands) {
         return null;
     }
-    const [target] = elements;
     const {openedDialog} = overlayController;
     const menuOpened = Boolean(
         openedDialog &&
-        openedDialog.target === target &&
         openedDialog.knownType === 'connectionsMenu'
     );
     return (
@@ -292,7 +290,7 @@ export function SelectionActionConnections(props: SelectionActionConnectionsProp
                 if (menuOpened) {
                     overlayController.hideDialog();
                 } else {
-                    commands.trigger('show', {target});
+                    commands.trigger('show', {targets: elements});
                 }
             }}
         />

--- a/src/workspace/defaultWorkspace.tsx
+++ b/src/workspace/defaultWorkspace.tsx
@@ -98,7 +98,13 @@ export function DefaultWorkspace(props: DefaultWorkspaceProps) {
                             />
                         )}
                         {haloLink === null ? null : <HaloLink {...haloLink} />}
-                        {selection === null ? null : <Selection {...selection} />}
+                        {selection === null ? null : (
+                            <Selection {...selection}
+                                connectionsMenuCommands={
+                                    connectionsMenu === null ? undefined : connectionsMenuCommands
+                                }
+                            />
+                        )}
                         {navigator === null ? null : <Navigator {...navigator} />}
                         {toolbar === null ? null : <Toolbar {...toolbar} />}
                         {zoomControl === null ? null : <ZoomControl {...zoomControl} />}


### PR DESCRIPTION
Additional changes:
 - Add `inexactCount` parameter to `DataProvider.connectedLinkStats()`;
 - Improve JSDoc for `DataProvider` and `SparqlDataProviderSettings`;
 - Run `onClose` when implicitly closing a dialog (e.g. opening another on a different target);
