### PR TITLE
Add ability to group entity elements via `EntityGroup`

### DIFF
--- a/src/data/schema.ts
+++ b/src/data/schema.ts
@@ -16,3 +16,7 @@ export namespace TemplateProperties {
     export const CustomLabel = 'urn:reactodia:customLabel';
     export const LayoutOnly = 'urn:reactodia:layoutOnly';
 }
+
+export interface PinnedProperties {
+    readonly [propertyId: string]: boolean;
+}

--- a/src/diagram/canvasApi.ts
+++ b/src/diagram/canvasApi.ts
@@ -127,12 +127,34 @@ export interface ScaleOptions extends ViewportOptions {
     pivot?: Vector;
 }
 
+/**
+ * Options for exporting diagram as SVG image.
+ */
 export interface ExportSvgOptions {
+    /**
+     * CSS selectors to exclude specific DOM elements from the exported diagram.
+     *
+     * By default, any element with `data-reactodia-no-export` is removed.
+     *
+     * @default ["[data-reactodia-no-export]"]
+     */
     removeByCssSelectors?: ReadonlyArray<string>;
-    /** @default false */
+    /**
+     * Whether to prepend XML encoding header to the exported SVG string.
+     *
+     * Prepended header:
+     * ```xml
+     * <?xml version="1.0" encoding="UTF-8"?>
+     * ```
+     *
+     * @default false
+     */
     addXmlHeader?: boolean;
 }
 
+/**
+ * Options for exporting diagram as raster image (e.g. JPEG, PNG, etc).
+ */
 export interface ExportRasterOptions extends ExportSvgOptions, ToDataURLOptions {}
 
 export type CanvasWidgetAttachment = 'viewport' | 'overElements' | 'overLinks';

--- a/src/diagram/commands.ts
+++ b/src/diagram/commands.ts
@@ -18,7 +18,7 @@ export class RestoreGeometry implements Command {
         return RestoreGeometry.captureElementsAndLinks(model.elements, model.links);
     }
 
-    private static captureElementsAndLinks(
+    static captureElementsAndLinks(
         elements: ReadonlyArray<Element>,
         links: ReadonlyArray<Link>,
     ) {

--- a/src/diagram/elementLayer.tsx
+++ b/src/diagram/elementLayer.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { findDOMNode } from 'react-dom';
+import { findDOMNode, flushSync } from 'react-dom';
 
 import { EventObserver } from '../coreUtils/events';
 import { Debouncer } from '../coreUtils/scheduler';
@@ -159,11 +159,13 @@ export class ElementLayer extends React.Component<ElementLayerProps, State> {
             this.requestRedrawAll(RedrawFlags.RecomputeBlurred);
         });
         this.listener.listen(renderingState.events, 'syncUpdate', ({layer}) => {
-            if (layer === RenderingLayer.Element) {
-                this.delayedRedraw.runSynchronously();
-            } else if (layer === RenderingLayer.ElementSize) {
-                this.delayedUpdateSizes.runSynchronously();
-            }
+            flushSync(() => {
+                if (layer === RenderingLayer.Element) {
+                    this.delayedRedraw.runSynchronously();
+                } else if (layer === RenderingLayer.ElementSize) {
+                    this.delayedUpdateSizes.runSynchronously();
+                }
+            });
         });
     }
 

--- a/src/diagram/layout.ts
+++ b/src/diagram/layout.ts
@@ -196,13 +196,17 @@ export function calculateAveragePosition(
 
 export function placeElementsAround(params: {
     elements: ReadonlyArray<Element>;
+    targetElement: Element;
     model: DiagramModel;
     sizeProvider: SizeProvider;
-    preferredLinksLength: number;
-    targetElement: Element;
+    /** @default 300 */
+    preferredLinksLength?: number;
     startAngle?: number;
 }): void {
-    const {elements, model, sizeProvider, targetElement, preferredLinksLength} = params;
+    const {
+        elements, model, sizeProvider, targetElement,
+        preferredLinksLength = 300,
+    } = params;
     const capturedGeometry = RestoreGeometry.capture(model);
 
     const targetElementBounds = boundsOf(targetElement, sizeProvider);

--- a/src/diagram/linkLayer.tsx
+++ b/src/diagram/linkLayer.tsx
@@ -568,6 +568,7 @@ class VertexTools extends React.Component<{
         const transform = `translate(${x + 2 * vertexRadius},${y - 2 * vertexRadius})scale(${vertexRadius})`;
         return (
             <g className={`${LINK_VERTICES_CLASS}__handle`}
+                data-reactodia-no-export='true'
                 transform={transform}
                 onPointerDown={this.onRemoveVertex}>
                 <title>Remove vertex</title>

--- a/src/diagram/linkRouter.ts
+++ b/src/diagram/linkRouter.ts
@@ -11,7 +11,7 @@ export class DefaultLinkRouter implements LinkRouter {
         const routings: RoutedLinks = new Map();
 
         for (const link of model.links) {
-            if (routings.has(link.id)) {
+            if (routings.has(link.id) || !model.shouldRenderLink(link)) {
                 continue;
             }
             // The cell is a link. Let's find its source and target models.

--- a/src/diagram/model.ts
+++ b/src/diagram/model.ts
@@ -24,8 +24,18 @@ export interface DiagramModelEvents {
 }
 
 export interface GraphStructure {
+    /**
+     * [RDF term factory](https://rdf.js.org/data-model-spec/#datafactory-interface)
+     * to create RDF terms like IRIs, literals, etc.
+     */
     get factory(): Rdf.DataFactory;
+    /**
+     * All elements on the diagram.
+     */
     get elements(): ReadonlyArray<Element>;
+    /**
+     * All links between elements on the diagram.
+     */
     get links(): ReadonlyArray<Link>;
 
     getElement(elementId: string): Element | undefined;
@@ -35,6 +45,16 @@ export interface GraphStructure {
     sourceOf(link: Link): Element | undefined;
     targetOf(link: Link): Element | undefined;
     getLinkVisibility(linkTypeId: LinkTypeIri): LinkTypeVisibility;
+    /**
+     * Specifies whether a link should be displayed on a canvas at all.
+     *
+     * Note that the result is cached, so it should stay the same
+     * unless the link is removed and re-added to the model.
+     *
+     * By default every link is rendered but this could be overridden
+     * in a derived model.
+     */
+    shouldRenderLink(link: Link): boolean;
 }
 
 export interface DiagramModelOptions {
@@ -138,6 +158,10 @@ export class DiagramModel implements GraphStructure {
 
     setLinkVisibility(linkTypeId: LinkTypeIri, value: LinkTypeVisibility): void {
         this.graph.setLinkVisibility(linkTypeId, value);
+    }
+
+    shouldRenderLink(link: Link): boolean {
+        return true;
     }
 
     protected resetGraph(): void {

--- a/src/diagram/paperArea.tsx
+++ b/src/diagram/paperArea.tsx
@@ -814,7 +814,7 @@ export class PaperArea extends React.Component<PaperAreaProps, State> implements
             preserveDimensions: true,
             convertImagesToDataUris: true,
             removeByCssSelectors: [
-                '.reactodia-link-vertices__handle',
+                '[data-reactodia-no-export]',
                 ...removeByCssSelectors
             ],
             watermarkSvg: this.props.watermarkSvg,

--- a/src/editor/authoredEntity.tsx
+++ b/src/editor/authoredEntity.tsx
@@ -3,6 +3,8 @@ import * as React from 'react';
 import { mapAbortedToNull } from '../coreUtils/async';
 import { useObservedProperty } from '../coreUtils/hooks';
 
+import { ElementModel } from '../data/model';
+
 import { Element } from '../diagram/elements';
 
 import { EntityElement } from '../editor/dataElements';
@@ -13,7 +15,7 @@ export interface AuthoredEntityContext {
     editedIri?: string;
     canEdit: boolean | undefined;
     canDelete: boolean | undefined;
-    onEdit: () => void;
+    onEdit: (target: Element) => void;
     onDelete: () => void;
 }
 
@@ -25,10 +27,9 @@ enum AllowedActions {
 }
 
 export function useAuthoredEntity(
-    element: Element,
+    data: ElementModel | undefined,
     shouldLoad: boolean
 ): AuthoredEntityContext {
-    const data = element instanceof EntityElement ? element.data : undefined;
     const {editor, overlay} = useWorkspace();
 
     const [allowedActions, setAllowedActions] = React.useState<AllowedActions | undefined>();
@@ -73,9 +74,9 @@ export function useAuthoredEntity(
             ? undefined : Boolean(allowedActions & AllowedActions.Edit),
         canDelete: allowedActions === undefined
             ? undefined : Boolean(allowedActions & AllowedActions.Delete),
-        onEdit: () => {
-            if (element instanceof EntityElement) {
-                overlay.showEditEntityForm(element);
+        onEdit: (target: Element) => {
+            if (target instanceof EntityElement) {
+                overlay.showEditEntityForm(target);
             }
         },
         onDelete: () => {

--- a/src/editor/dataFetcher.ts
+++ b/src/editor/dataFetcher.ts
@@ -9,7 +9,9 @@ import { DataProvider } from '../data/provider';
 
 import { Graph } from '../diagram/graph';
 
-import { EntityElement, ElementType, LinkType, PropertyType } from './dataElements';
+import {
+    EntityElement, EntityGroup, EntityGroupItem, ElementType, LinkType, PropertyType,
+} from './dataElements';
 import { DataGraph } from './dataGraph';
 
 export interface DataFetcherEvents {
@@ -165,6 +167,20 @@ export class DataFetcher {
                 const loadedModel = elements.get(element.iri);
                 if (loadedModel) {
                     element.setData(loadedModel);
+                }
+            } else if (element instanceof EntityGroup) {
+                let hasLoadedModel = false;
+                for (const item of element.items) {
+                    if (elements.has(item.data.id)) {
+                        hasLoadedModel = true;
+                    }
+                }
+                if (hasLoadedModel) {
+                    const loadedItems = element.items.map((item): EntityGroupItem => {
+                        const loadedData = elements.get(item.data.id);
+                        return loadedData ? {...item, data: loadedData} : item;
+                    });
+                    element.setItems(loadedItems);
                 }
             }
         }

--- a/src/editor/elementGrouping.ts
+++ b/src/editor/elementGrouping.ts
@@ -1,0 +1,104 @@
+import { ElementIri } from '../data/model';
+
+import type { CanvasApi } from '../diagram/canvasApi';
+import { RestoreGeometry } from '../diagram/commands';
+import { Rect, Vector, boundsOf, getContentFittingBox } from '../diagram/geometry';
+import { placeElementsAround } from '../diagram/layout';
+
+import { EntityElement, EntityGroup } from './dataElements';
+
+import type { WorkspaceContext } from '../workspace/workspaceContext';
+
+export async function groupEntitiesAnimated(
+    elements: ReadonlyArray<EntityElement>,
+    canvas: CanvasApi,
+    workspace: WorkspaceContext
+): Promise<EntityGroup> {
+    const {model} = workspace;
+    const batch = model.history.startBatch('Group entities');
+
+    const capturedGeometry = RestoreGeometry.captureElementsAndLinks(elements, []);
+
+    const fittingBox = getContentFittingBox(elements, [], canvas.renderingState);
+    const groupCenter = Rect.center(fittingBox);
+    await canvas.animateGraph(() => {
+        for (const element of elements) {
+            const bounds = boundsOf(element, canvas.renderingState);
+            const atCenter: Vector = {
+                x: groupCenter.x - bounds.width / 2,
+                y: groupCenter.y - bounds.height / 2,
+            };
+            const normal = Vector.normalize(Vector.subtract(element.position, groupCenter));
+            element.setPosition(Vector.add(
+                atCenter,
+                Vector.scale(normal, Math.min(bounds.width, bounds.height) / 2)
+            ));
+        }
+    });
+    
+    batch.history.registerToUndo(capturedGeometry);
+
+    const sortedEntities = [...elements].sort((a, b) => {
+        const aLabel = model.locale.formatLabel(a.data.label, a.data.id);
+        const bLabel = model.locale.formatLabel(b.data.label, b.data.id);
+        return aLabel.localeCompare(bLabel);
+    });
+
+    const group = model.group(sortedEntities);
+    canvas.renderingState.syncUpdate();
+
+    const bounds = boundsOf(group, canvas.renderingState);
+    group.setPosition({
+        x: groupCenter.x - bounds.width / 2,
+        y: groupCenter.y - bounds.height / 2,
+    });
+
+    batch.store();
+    return group;
+}
+
+export async function ungroupAllEntitiesAnimated(
+    groups: ReadonlyArray<EntityGroup>,
+    canvas: CanvasApi,
+    workspace: WorkspaceContext
+): Promise<EntityElement[]> {
+    const {model, performLayout} = workspace;
+    const batch = model.history.startBatch('Ungroup entities');
+
+    const ungrouped = model.ungroupAll(groups);
+    await performLayout({
+        canvas,
+        selectedElements: new Set(ungrouped),
+        animate: true,
+        zoomToFit: false,
+    });
+
+    batch.store();
+    return ungrouped;
+}
+
+export async function ungroupSomeEntitiesAnimated(
+    group: EntityGroup,
+    entities: ReadonlySet<ElementIri>,
+    canvas: CanvasApi,
+    workspace: WorkspaceContext
+): Promise<EntityElement[]> {
+    const {model} = workspace;
+    const batch = model.history.startBatch('Ungroup entities');
+
+    const ungrouped = model.ungroupSome(group, entities);
+
+    canvas.renderingState.syncUpdate();
+
+    await canvas.animateGraph(() => {
+        placeElementsAround({
+            elements: ungrouped.filter(element => entities.has(element.data.id)),
+            model,
+            sizeProvider: canvas.renderingState,
+            targetElement: group,
+        });
+    });
+
+    batch.store();
+    return ungrouped;
+}

--- a/src/editor/observedElement.ts
+++ b/src/editor/observedElement.ts
@@ -3,17 +3,14 @@ import * as React from 'react';
 import { Listener } from '../coreUtils/events';
 import { KeyedObserver } from '../coreUtils/keyedObserver';
 
-import { ElementTypeIri, PropertyTypeIri } from '../data/model';
-
-import { Element } from '../diagram/elements';
+import { ElementModel, ElementTypeIri, PropertyTypeIri } from '../data/model';
 
 import { useWorkspace } from '../workspace/workspaceContext';
 
 import { DataDiagramModel } from './dataDiagramModel';
-import { EntityElement, ElementTypeEvents, PropertyTypeEvents } from './dataElements';
+import { ElementTypeEvents, PropertyTypeEvents } from './dataElements';
 
-export function useObservedElement(element: Element): void {
-    const data = element instanceof EntityElement ? element.data : undefined;
+export function useObservedElement(data: ElementModel | undefined): void {
     const {model} = useWorkspace();
 
     interface ObservedState {

--- a/src/templates/classicTemplate.tsx
+++ b/src/templates/classicTemplate.tsx
@@ -11,21 +11,22 @@ const CLASS_NAME = 'reactodia-classic-template';
 
 export function ClassicTemplate(props: TemplateProps) {
     const {element, isExpanded} = props;
-    const {model, getElementTypeStyle} = useWorkspace();
-    useObservedElement(element);
+    const data = element instanceof EntityElement ? element.data : undefined;
 
-    if (!(element instanceof EntityElement)) {
+    const {model, getElementTypeStyle} = useWorkspace();
+    useObservedElement(data);
+
+    if (!data) {
         return null;
     }
 
-    const {data} = element;
     const types = data?.types ?? [];
     const {color, icon} = getElementTypeStyle(types);
 
     const typesLabel = types.length > 0
         ? model.locale.formatElementTypes(types).join(', ')
         : 'Thing';
-    const label = model.locale.formatLabel(data?.label, element.iri);
+    const label = model.locale.formatLabel(data?.label, data.id);
     const propertyList = model.locale.formatPropertyList(data?.properties ?? {});
 
     const image = data?.image ? (
@@ -44,9 +45,9 @@ export function ClassicTemplate(props: TemplateProps) {
                 </div>
                 <div className={`${CLASS_NAME}__iri-container`}>
                     <a className={`${CLASS_NAME}__iri`}
-                        title={element.iri}
-                        href={element.iri}>
-                        {element.iri}
+                        title={data.id}
+                        href={data.id}>
+                        {data.id}
                     </a>
                 </div>
             </div>
@@ -75,7 +76,7 @@ export function ClassicTemplate(props: TemplateProps) {
             </div>
             {image}
             <div className={`${CLASS_NAME}__body`} style={{borderColor: color}}>
-                <WithFetchStatus type='element' target={element.iri}>
+                <WithFetchStatus type='element' target={data.id}>
                     <span className={`${CLASS_NAME}__label`} title={label}>
                         {label}
                     </span>

--- a/src/templates/standardTemplate.tsx
+++ b/src/templates/standardTemplate.tsx
@@ -3,13 +3,16 @@ import classnames from 'classnames';
 
 import type * as Rdf from '../data/rdf/rdfModel';
 import { ElementModel, isEncodedBlank } from '../data/model';
-import { TemplateProperties } from '../data/schema';
+import { PinnedProperties, TemplateProperties } from '../data/schema';
 
+import { CanvasApi, useCanvas } from '../diagram/canvasApi';
+import { Element } from '../diagram/elements';
 import { HtmlSpinner } from '../diagram/spinner';
 
 import { AuthoredEntityContext, useAuthoredEntity } from '../editor/authoredEntity';
 import { AuthoringState } from '../editor/authoringState';
-import { EntityElement } from '../editor/dataElements';
+import { EntityLocaleFormatter } from '../editor/dataDiagramModel';
+import { EntityElement, EntityGroup, EntityGroupItem } from '../editor/dataElements';
 import { useObservedElement } from '../editor/observedElement';
 import { WithFetchStatus } from '../editor/withFetchStatus';
 
@@ -17,108 +20,58 @@ import { type WorkspaceContext, useWorkspace } from '../workspace/workspaceConte
 
 import { TemplateProps, FormattedProperty } from '../diagram/customization';
 
-export function StandardTemplate(props: TemplateProps) {
-    const {element, isExpanded} = props;
-
-    const workspace = useWorkspace();
-    const data = element instanceof EntityElement ? element.data : undefined;
-    const entityContext = useAuthoredEntity(element, isExpanded);
-    useObservedElement(element);
-
-    if (!data) {
-        return null;
-    }
-    return (
-        <StandardTemplateInner {...props}
-            data={data}
-            workspace={workspace}
-            entityContext={entityContext}
-        />
-    );
-}
-
-interface StandardTemplateInnerProps extends TemplateProps {
-    data: ElementModel;
-    workspace: WorkspaceContext;
-    entityContext: AuthoredEntityContext;
-}
-
 const CLASS_NAME = 'reactodia-standard-template';
 const FOAF_NAME = 'http://xmlns.com/foaf/0.1/name';
 
-class StandardTemplateInner extends React.Component<StandardTemplateInnerProps> {
-    render() {
-        const {data, isExpanded, workspace: {model, editor, getElementTypeStyle}} = this.props;
-        const {color, icon} = getElementTypeStyle(data.types);
-
-        const isNewElement = AuthoringState.isNewElement(editor.authoringState, data.id);
-        const leftStripeColor = isNewElement ? 'white' : color;
-        const pinnedPropertyKeys = this.findPinnedProperties() ?? {};
-
-        const typesLabel = data.types.length > 0
-            ? model.locale.formatElementTypes(data.types).join(', ')
-            : 'Thing';
-        const label = this.formatLabel();
-        const propertyList = model.locale.formatPropertyList(data.properties);
-        const pinnedProperties = propertyList.filter(p => Boolean(
-            Object.prototype.hasOwnProperty.call(pinnedPropertyKeys, p.propertyId) &&
-            pinnedPropertyKeys[p.propertyId]
-        ));
-
+export function StandardTemplate(props: TemplateProps) {
+    const {element} = props;
+    if (element instanceof EntityElement) {
         return (
-            <div className={CLASS_NAME}>
-                <div className={`${CLASS_NAME}__main`} style={{backgroundColor: leftStripeColor, borderColor: color}}>
-                    <div className={`${CLASS_NAME}__body`} style={{borderLeftColor: color}}>
-                        <div className={`${CLASS_NAME}__body-horizontal`}>
-                            {this.renderThumbnail(typesLabel, color, icon)}
-                            <div className={`${CLASS_NAME}__body-content`}>
-                                <div title={typesLabel} className={`${CLASS_NAME}__type`}>
-                                    <div className={`${CLASS_NAME}__type-value`}>
-                                        {this.renderTypes()}
-                                    </div>
-                                </div>
-                                <WithFetchStatus type='element' target={data.id}>
-                                    <div className={`${CLASS_NAME}__label`} title={label}>{label}</div>
-                                </WithFetchStatus>
-                            </div>
-                        </div>
-                        {pinnedProperties.length > 0 ? (
-                            <div className={`${CLASS_NAME}__pinned-props`} style={{borderColor: color}}>
-                                {this.renderProperties(pinnedProperties)}
-                            </div>
-                        ) : null}
-                    </div>
-                </div>
-                {isExpanded ? (
-                    <div className={`${CLASS_NAME}__dropdown`} style={{borderColor: color}}>
-                        {this.renderImage(color)}
-                        <div className={`${CLASS_NAME}__dropdown-content`}>
-                            {this.renderIri()}
-                            {this.renderProperties(propertyList)}
-                            {editor.inAuthoringMode ? <hr className={`${CLASS_NAME}__hr`} /> : null}
-                            {editor.inAuthoringMode ? this.renderActions() : null}
-                        </div>
-                    </div>
-                ) : null}
-            </div>
+            <StandardTemplateStandalone {...props}
+                data={element.data}
+                target={element}
+            />
         );
+    } else if (element instanceof EntityGroup) {
+        return (
+            <StandardTemplateGroup {...props}
+                items={element.items}
+                target={element}
+            />
+        );
+    } else {
+        return null;
     }
+}
 
-    private formatLabel(): string {
-        const {data, workspace: {model}} = this.props;
-        const foafName = Object.prototype.hasOwnProperty.call(data.properties, FOAF_NAME)
-            ? data.properties[FOAF_NAME] : undefined;
-        if (foafName) {
-            const literals = foafName.filter((v): v is Rdf.Literal => v.termType === 'Literal');
-            if (literals.length > 0) {
-                return model.locale.formatLabel(literals, data.id);
-            }
-        }
-        return model.locale.formatLabel(data.label, data.id);
-    }
+interface StandardTemplateBodyProps extends TemplateProps {
+    data: ElementModel;
+    target: Element;
+}
 
-    private renderTypes() {
-        const {data, workspace: {model}} = this.props;
+function StandardTemplateStandalone(props: StandardTemplateBodyProps) {
+    const {data, isExpanded, elementState, target} = props;
+    const workspace = useWorkspace();
+    const {model, editor, getElementTypeStyle} = workspace;
+
+    const entityContext = useAuthoredEntity(data, isExpanded);
+    useObservedElement(data);
+
+    const label = formatEntityLabel(data, model.locale);
+    const typesLabel = formatEntityTypes(data, model.locale);
+    const {color: baseColor, icon: iconUrl} = getElementTypeStyle(data.types);
+    const rootStyle = {
+        '--reactodia-standard-entity-color': baseColor,
+    } as React.CSSProperties;
+
+    const propertyList = model.locale.formatPropertyList(data.properties);
+    const pinnedPropertyKeys = findPinnedProperties() ?? {};
+    const pinnedProperties = propertyList.filter(p => Boolean(
+        Object.prototype.hasOwnProperty.call(pinnedPropertyKeys, p.propertyId) &&
+        pinnedPropertyKeys[p.propertyId]
+    ));
+
+    function renderTypes() {
         if (data.types.length === 0) {
             return 'Thing';
         }
@@ -136,8 +89,7 @@ class StandardTemplateInner extends React.Component<StandardTemplateInnerProps> 
         });
     }
 
-    private findPinnedProperties(): PinnedProperties | undefined {
-        const {isExpanded, elementState} = this.props;
+    function findPinnedProperties(): PinnedProperties | undefined {
         if (isExpanded || !elementState) {
             return undefined;
         }
@@ -145,59 +97,7 @@ class StandardTemplateInner extends React.Component<StandardTemplateInnerProps> 
         return pinned;
     }
 
-    private renderProperties(propsAsList: ReadonlyArray<FormattedProperty>) {
-        if (!propsAsList.length) {
-            return <div>no properties</div>;
-        }
-
-        return (
-            <div role='list'
-                className={`${CLASS_NAME}__properties`}>
-                {propsAsList.map(({propertyId, label, values}) => {
-                    return (
-                        <div key={propertyId}
-                            role='listitem'
-                            className={`${CLASS_NAME}__properties-row`}>
-                            <WithFetchStatus type='propertyType' target={propertyId}>
-                                <div className={`${CLASS_NAME}__properties-key`}
-                                    title={`${label} (${propertyId})`}>
-                                    {label}
-                                </div>
-                            </WithFetchStatus>
-                            <div className={`${CLASS_NAME}__properties-values`}>
-                                {values.map((term, index) => (
-                                    <div key={index}
-                                        className={`${CLASS_NAME}__properties-value`}
-                                        title={term.value}
-                                        lang={
-                                            term.termType === 'Literal' && term.language
-                                                ? term.language : undefined
-                                        }>
-                                        {term.value}
-                                    </div>
-                                ))}
-                            </div>
-                        </div>
-                    );
-                })}
-            </div>
-        );
-    }
-
-    private renderImage(color: string) {
-        const {data} = this.props;
-
-        if (!data.image) { return null; }
-
-        return (
-            <div className={`${CLASS_NAME}__photo`} style={{borderColor: color}}>
-                <img src={data.image} className={`${CLASS_NAME}__photo-image`} />
-            </div>
-        );
-    }
-
-    private renderIri() {
-        const {data, entityContext} = this.props;
+    function renderIri() {
         const finalIri = entityContext.editedIri === undefined ? data.id : entityContext.editedIri;
         return (
             <div>
@@ -220,9 +120,7 @@ class StandardTemplateInner extends React.Component<StandardTemplateInnerProps> 
         );
     }
 
-    private renderThumbnail(typesLabel: string, color: string, iconUrl: string | undefined) {
-        const {data} = this.props;
-
+    function renderThumbnail() {
         if (data.image) {
             return (
                 <div className={`${CLASS_NAME}__thumbnail`} aria-hidden='true'>
@@ -238,48 +136,256 @@ class StandardTemplateInner extends React.Component<StandardTemplateInnerProps> 
         }
 
         return (
-            <div className={`${CLASS_NAME}__thumbnail`} aria-hidden='true' style={{color}}>
+            <div className={`${CLASS_NAME}__thumbnail`} aria-hidden='true'>
                 {typesLabel.length > 0 ? typesLabel.charAt(0).toUpperCase() : '✳'}
             </div>
         );
     }
 
-    private renderActions() {
-        const {entityContext} = this.props;
-        const {canEdit, canDelete, onEdit, onDelete} = entityContext;
-        const SPINNER_WIDTH = 15;
-        const SPINNER_HEIGHT = 12;
-        return (
-            <div className={`${CLASS_NAME}__actions`}>
-                <button type='button'
-                    className={classnames(
-                        `${CLASS_NAME}__delete-button`,
-                        'reactodia-btn reactodia-btn-default'
-                    )}
-                    title={canDelete ? 'Delete entity' : 'Deletion is unavailable for the selected element'}
-                    disabled={!canDelete}
-                    onClick={onDelete}>
-                    {canEdit === undefined
-                        ? <HtmlSpinner width={SPINNER_WIDTH} height={SPINNER_HEIGHT} />
-                        : 'Delete'}
-                </button>
-                <button type='button'
-                    className={classnames(
-                        `${CLASS_NAME}__edit-button`,
-                        'reactodia-btn reactodia-btn-default'
-                    )}
-                    title={canEdit ? 'Edit entity' : 'Editing is unavailable for the selected element'}
-                    disabled={!canEdit}
-                    onClick={onEdit}>
-                    {canEdit === undefined
-                        ? <HtmlSpinner width={SPINNER_WIDTH} height={SPINNER_HEIGHT} />
-                        : 'Edit'}
-                </button>
+    return (
+        <div style={rootStyle}
+            className={classnames(
+                CLASS_NAME,
+                `${CLASS_NAME}--standalone`,
+                getEntityAuthoredStatusClass(data, editor.authoringState)
+            )}>
+            <div className={`${CLASS_NAME}__main`}>
+                <div className={`${CLASS_NAME}__body`}>
+                    <div className={`${CLASS_NAME}__body-horizontal`}>
+                        {renderThumbnail()}
+                        <div className={`${CLASS_NAME}__body-content`}>
+                            <div title={typesLabel} className={`${CLASS_NAME}__type`}>
+                                <div className={`${CLASS_NAME}__type-value`}>
+                                    {renderTypes()}
+                                </div>
+                            </div>
+                            <WithFetchStatus type='element' target={data.id}>
+                                <div className={`${CLASS_NAME}__label`} title={label}>{label}</div>
+                            </WithFetchStatus>
+                        </div>
+                    </div>
+                    {pinnedProperties.length > 0 ? (
+                        <div className={`${CLASS_NAME}__pinned-props`}>
+                            <PropertyList properties={pinnedProperties} />
+                        </div>
+                    ) : null}
+                </div>
             </div>
-        );
-    }
+            {isExpanded ? (
+                <div className={`${CLASS_NAME}__dropdown`}>
+                    {data.image ? (
+                        <div className={`${CLASS_NAME}__photo`}>
+                            <img src={data.image} className={`${CLASS_NAME}__photo-image`} />
+                        </div>
+                    ) : null}
+                    <div className={`${CLASS_NAME}__dropdown-content`}>
+                        {renderIri()}
+                        <PropertyList properties={propertyList} />
+                        {editor.inAuthoringMode ? <>
+                            <hr className={`${CLASS_NAME}__hr`}
+                                data-reactodia-no-export='true'
+                            />
+                            <Actions target={target}
+                                entityContext={entityContext}
+                            />
+                        </> : null}
+                    </div>
+                </div>
+            ) : null}
+        </div>
+    );
 }
 
-interface PinnedProperties {
-    [propertyId: string]: boolean;
+interface StandardTemplateGroupProps extends TemplateProps {
+    items: ReadonlyArray<EntityGroupItem>;
+    target: EntityGroup;
+}
+
+function StandardTemplateGroup(props: StandardTemplateGroupProps) {
+    const {items, target} = props;
+    const {canvas} = useCanvas();
+    const workspace = useWorkspace();
+    const {getElementStyle} = workspace;
+
+    const {color: groupColor} = getElementStyle(target);
+    const groupStyle = {
+        '--reactodia-standard-group-color': groupColor,
+    } as React.CSSProperties;
+
+    return (
+        <div className={classnames(CLASS_NAME, `${CLASS_NAME}--group`)}
+            style={groupStyle}>
+            {items.map(item => (
+                <StandardTemplateGroupItem {...props}
+                    key={item.data.id}
+                    data={item.data}
+                    isExpanded={false}
+                    target={target}
+                    canvas={canvas}
+                    workspace={workspace}
+                />
+            ))}
+        </div>
+    );
+}
+
+interface StandardTemplateGroupItemProps extends TemplateProps {
+    data: ElementModel;
+    target: EntityGroup;
+    canvas: CanvasApi;
+    workspace: WorkspaceContext;
+}
+
+function StandardTemplateGroupItem(props: StandardTemplateGroupItemProps) {
+    const {data, target, canvas, workspace: {model, editor, ungroupSome, getElementTypeStyle}} = props;
+
+    const label = formatEntityLabel(data, model.locale);
+    const iri = model.locale.formatIri(data.id);
+    const typesLabel = formatEntityTypes(data, model.locale);
+    const title = `${label}\nIRI:${iri}\nTypes: ${typesLabel}`;
+
+    const authoringStatusClass = getEntityAuthoredStatusClass(data, editor.authoringState);
+    const {color: baseColor} = getElementTypeStyle(data.types);
+    const itemStyle = {
+        '--reactodia-standard-entity-color': baseColor,
+    } as React.CSSProperties;
+
+    return (
+        <div className={classnames(`${CLASS_NAME}__item`, authoringStatusClass)}
+            style={itemStyle}>
+            <div className={`${CLASS_NAME}__item-stripe`} aria-hidden='true' />
+            <div className={`${CLASS_NAME}__item-body`}>
+                <WithFetchStatus type='element' target={data.id}>
+                    <div className={`${CLASS_NAME}__label`} title={title}>{label}</div>
+                </WithFetchStatus>
+                <button type='button'
+                    className={classnames(
+                        `${CLASS_NAME}__ungroup-one-button`,
+                        'reactodia-btn reactodia-btn-default'
+                    )}
+                    data-reactodia-no-export='true'
+                    title='Ungroup an entity'
+                    onClick={() => ungroupSome({
+                        group: target,
+                        entities: new Set([data.id]),
+                        canvas,
+                    })}
+                />
+            </div>
+        </div>
+    );
+}
+
+function formatEntityLabel(data: ElementModel, locale: EntityLocaleFormatter): string {
+    const foafName = Object.prototype.hasOwnProperty.call(data.properties, FOAF_NAME)
+        ? data.properties[FOAF_NAME] : undefined;
+    if (foafName) {
+        const literals = foafName.filter((v): v is Rdf.Literal => v.termType === 'Literal');
+        if (literals.length > 0) {
+            return locale.formatLabel(literals, data.id);
+        }
+    }
+    return locale.formatLabel(data.label, data.id);
+}
+
+function formatEntityTypes(data: ElementModel, locale: EntityLocaleFormatter): string {
+    return data.types.length > 0
+        ? locale.formatElementTypes(data.types).join(', ')
+        : 'Thing';
+}
+
+function getEntityAuthoredStatusClass(data: ElementModel, state: AuthoringState): string | undefined {
+    const event = state.elements.get(data.id);
+    if (!event) {
+        return undefined;
+    }
+    return (
+        event.deleted ? `${CLASS_NAME}--deleted` :
+        event.before ? `${CLASS_NAME}--changed` :
+        `${CLASS_NAME}--new`
+    );
+}
+
+function PropertyList(props: {
+    properties: ReadonlyArray<FormattedProperty>;
+}) {
+    const {properties} = props;
+
+    if (properties.length === 0) {
+        return <div>no properties</div>;
+    }
+
+    return (
+        <div role='list'
+            className={`${CLASS_NAME}__properties`}>
+            {properties.map(({propertyId, label, values}) => {
+                return (
+                    <div key={propertyId}
+                        role='listitem'
+                        className={`${CLASS_NAME}__properties-row`}>
+                        <WithFetchStatus type='propertyType' target={propertyId}>
+                            <div className={`${CLASS_NAME}__properties-key`}
+                                title={`${label} (${propertyId})`}>
+                                {label}
+                            </div>
+                        </WithFetchStatus>
+                        <div className={`${CLASS_NAME}__properties-values`}>
+                            {values.map((term, index) => (
+                                <div key={index}
+                                    className={`${CLASS_NAME}__properties-value`}
+                                    title={term.value}
+                                    lang={
+                                        term.termType === 'Literal' && term.language
+                                            ? term.language : undefined
+                                    }>
+                                    {term.value}
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                );
+            })}
+        </div>
+    );
+}
+
+function Actions(props: {
+    target: Element;
+    entityContext: AuthoredEntityContext;
+}) {
+    const {
+        target,
+        entityContext: {canEdit, canDelete, onEdit, onDelete},
+    } = props;
+    const SPINNER_WIDTH = 15;
+    const SPINNER_HEIGHT = 12;
+    return (
+        <div className={`${CLASS_NAME}__actions`}
+            data-reactodia-no-export='true'>
+            <button type='button'
+                className={classnames(
+                    `${CLASS_NAME}__delete-button`,
+                    'reactodia-btn reactodia-btn-default'
+                )}
+                title={canDelete ? 'Delete entity' : 'Deletion is unavailable for the selected element'}
+                disabled={!canDelete}
+                onClick={onDelete}>
+                {canEdit === undefined
+                    ? <HtmlSpinner width={SPINNER_WIDTH} height={SPINNER_HEIGHT} />
+                    : 'Delete'}
+            </button>
+            <button type='button'
+                className={classnames(
+                    `${CLASS_NAME}__edit-button`,
+                    'reactodia-btn reactodia-btn-default'
+                )}
+                title={canEdit ? 'Edit entity' : 'Editing is unavailable for the selected element'}
+                disabled={!canEdit}
+                onClick={() => onEdit(target)}>
+                {canEdit === undefined
+                    ? <HtmlSpinner width={SPINNER_WIDTH} height={SPINNER_HEIGHT} />
+                    : 'Edit'}
+            </button>
+        </div>
+    );
 }

--- a/src/widgets/connectionsMenu.tsx
+++ b/src/widgets/connectionsMenu.tsx
@@ -15,7 +15,7 @@ import { placeElementsAround } from '../diagram/layout';
 import { DiagramModel } from '../diagram/model';
 
 import { DataDiagramModel, requestElementData, restoreLinksBetweenElements } from '../editor/dataDiagramModel';
-import { EntityElement } from '../editor/dataElements';
+import { EntityElement, iterateEntitiesOf } from '../editor/dataElements';
 import { WithFetchStatus } from '../editor/withFetchStatus';
 
 import type { InstancesSearchCommands } from '../widgets/instancesSearch';
@@ -80,8 +80,8 @@ export function ConnectionsMenu(props: ConnectionsMenuProps) {
 
             const targetIris = new Set<ElementIri>();
             for (const target of targets) {
-                if (target instanceof EntityElement) {
-                    targetIris.add(target.iri);
+                for (const entity of iterateEntitiesOf(target)) {
+                    targetIris.add(entity.id);
                 }
             }
 
@@ -535,7 +535,6 @@ class ConnectionsMenuInner extends React.Component<ConnectionsMenuInnerProps, Me
             model,
             sizeProvider: canvas.renderingState,
             targetElement: placeTarget,
-            preferredLinksLength: 300,
         });
 
         if (linkTypeId && model.getLinkVisibility(linkTypeId) === 'hidden') {

--- a/src/widgets/halo.tsx
+++ b/src/widgets/halo.tsx
@@ -12,7 +12,8 @@ import type { ConnectionsMenuCommands } from './connectionsMenu';
 import type { InstancesSearchCommands } from './instancesSearch';
 import {
     SelectionActionRemove, SelectionActionExpand, SelectionActionAnchor,
-    SelectionActionConnections, SelectionActionAddToFilter, SelectionActionEstablishLink,
+    SelectionActionConnections, SelectionActionAddToFilter, SelectionActionGroup,
+    SelectionActionEstablishLink,
 } from './selectionAction';
 
 export interface HaloProps {
@@ -28,6 +29,7 @@ export interface HaloProps {
      * **Default**:
      * ```jsx
      * <>
+     *   <SelectionActionGroup dock='nw' dockColumn={1} />
      *   <SelectionActionRemove dock='ne' />
      *   <SelectionActionExpand dock='s' />
      *   <SelectionActionAnchor dock='w' />
@@ -144,6 +146,7 @@ class HaloInner extends React.Component<HaloInnerProps> {
         return (
             <div className={CLASS_NAME} style={style}>
                 {children ?? <>
+                    <SelectionActionGroup dock='nw' dockColumn={1} />
                     <SelectionActionRemove dock='ne' />
                     <SelectionActionExpand dock='s' />
                     <SelectionActionAnchor dock='w' />

--- a/src/widgets/navigator.tsx
+++ b/src/widgets/navigator.tsx
@@ -12,6 +12,7 @@ import {
 } from '../diagram/paper';
 import { type WorkspaceContext, useWorkspace } from '../workspace/workspaceContext';
 import { EntityElement } from '../workspace';
+import { EntityGroup } from '../editor/dataElements';
 
 export interface NavigatorProps {
     /**
@@ -222,14 +223,13 @@ class NavigatorInner extends React.Component<NavigatorInnerProps, State> {
     }
 
     private chooseElementColor(element: Element): string {
-        const {canvas, workspace: {model, getElementTypeStyle}} = this.props;
+        const {canvas, workspace: {getElementStyle}} = this.props;
         const {highlighter} = canvas.renderingState.shared;
         const isBlurred = highlighter && !highlighter(element);
         if (isBlurred) {
             return 'lightgray';
         }
-        const data = element instanceof EntityElement ? element.data : undefined;
-        const {color} = getElementTypeStyle(data?.types ?? []);
+        const {color} = getElementStyle(element);
         return color;
     }
 

--- a/src/widgets/selection.tsx
+++ b/src/widgets/selection.tsx
@@ -17,7 +17,7 @@ import { DiagramModel } from '../diagram/model';
 import type { ConnectionsMenuCommands } from './connectionsMenu';
 import {
     SelectionActionRemove, SelectionActionZoomToFit, SelectionActionLayout,
-    SelectionActionExpand, SelectionActionConnections,
+    SelectionActionExpand, SelectionActionConnections, SelectionActionGroup,
 } from './selectionAction';
 
 export interface SelectionProps {
@@ -36,9 +36,13 @@ export interface SelectionProps {
      * **Default**:
      * ```jsx
      * <>
-     *   <SelectionActionRemove dock='ne' dockRow={1} />
-     *   <SelectionActionZoomToFit dock='ne' dockRow={2} />
-     *   <SelectionActionLayout dock='ne' dockRow={3} />
+     *   <SelectionActionZoomToFit dock='nw' dockColumn={1} />
+     *   <SelectionActionLayout dock='nw' dockColumn={2} />
+     *   <SelectionActionGroup dock='nw' dockColumn={3} />
+     *   <SelectionActionRemove dock='ne' />
+     *   <SelectionActionConnections dock='e'
+     *       commands={props.connectionsMenuCommands}
+     *   />
      *   <SelectionActionExpand dock='s' />
      * </>
      * ```
@@ -230,11 +234,11 @@ function SelectionBox(props: SelectionBoxProps) {
                 <div className={`${CLASS_NAME}__selectedActions`}
                     style={selectedBoxStyle}>
                     {children ?? <>
-                        <SelectionActionRemove dock='ne' dockRow={1} />
-                        <SelectionActionZoomToFit dock='ne' dockRow={2} />
-                        <SelectionActionLayout dock='ne' dockRow={3} />
-                        <SelectionActionConnections dock='ne'
-                            dockRow={4}
+                        <SelectionActionZoomToFit dock='nw' dockColumn={1} />
+                        <SelectionActionLayout dock='nw' dockColumn={2} />
+                        <SelectionActionGroup dock='nw' dockColumn={3} />
+                        <SelectionActionRemove dock='ne' />
+                        <SelectionActionConnections dock='e'
                             commands={connectionsMenuCommands}
                         />
                         <SelectionActionExpand dock='s' />

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -27,7 +27,8 @@ export * from './data/metadataApi';
 export * from './data/validationApi';
 export * from './data/provider';
 export {
-    TemplateProperties, DIAGRAM_CONTEXT_URL_V1, PLACEHOLDER_ELEMENT_TYPE, PLACEHOLDER_LINK_TYPE,
+    TemplateProperties, PinnedProperties,
+    DIAGRAM_CONTEXT_URL_V1, PLACEHOLDER_ELEMENT_TYPE, PLACEHOLDER_LINK_TYPE,
 } from './data/schema';
 export * from './data/composite/composite';
 export {
@@ -45,7 +46,10 @@ export * from './data/sparql/sparqlDataProviderSettings';
 
 export * from './diagram/canvasApi';
 export { defineCanvasWidget } from './diagram/canvasWidget';
-export { RestoreGeometry, setElementExpanded } from './diagram/commands';
+export {
+    RestoreGeometry, setElementExpanded, changeLinkTypeVisibility,
+    restoreCapturedLinkGeometry, restoreViewport,
+} from './diagram/commands';
 export * from './diagram/customization';
 export {
     Element, ElementEvents, ElementTemplateState,
@@ -76,11 +80,12 @@ export * from './editor/authoringState';
 export * from './editor/dataDiagramModel';
 export {
     EntityElement, EntityElementEvents, EntityElementProps,
+    EntityGroup, EntityGroupEvents, EntityGroupProps, EntityGroupItem,
     RelationLink, RelationLinkEvents, RelationLinkProps,
     ElementType, ElementTypeEvents,
     LinkType, LinkTypeEvents,
     PropertyType, PropertyTypeEvents,
-    setElementData, setLinkData,
+    iterateEntitiesOf, setElementData, setLinkData, setEntityGroupItems,
 } from './editor/dataElements';
 export {
     ChangeOperationsEvent, FetchOperation, FetchOperationFail,
@@ -97,7 +102,8 @@ export { ValidationState, ElementValidation, LinkValidation } from './editor/val
 export { WithFetchStatus, WithFetchStatusProps } from './editor/withFetchStatus';
 
 export {
-    SerializedLayout, SerializedDiagram, SerializedLinkOptions,
+    SerializedLayout, SerializedDiagram, SerializedLayoutElement, SerializedLayoutGroup,
+    SerializedLayoutGroupItem, SerializedLayoutLink, SerializedLinkOptions,
     makeSerializedDiagram, makeSerializedLayout,
 } from './editor/serializedDiagram';
 
@@ -151,6 +157,7 @@ export {
     SelectionActionAnchor, SelectionActionAnchorProps,
     SelectionActionConnections, SelectionActionConnectionsProps,
     SelectionActionAddToFilter, SelectionActionAddToFilterProps,
+    SelectionActionGroup, SelectionActionGroupProps,
     SelectionActionEstablishLink, SelectionActionEstablishLinkProps,
 } from './widgets/selectionAction';
 export { Toolbar, ToolbarProps } from './widgets/toolbar';
@@ -173,7 +180,9 @@ export {
     Workspace, WorkspaceProps, LoadedWorkspace, LoadedWorkspaceParams, useLoadedWorkspace,
 } from './workspace/workspace';
 export {
-    WorkspaceContext, WorkspaceEventHandler, WorkspaceEventKey, ProcessedTypeStyle, useWorkspace,
+    WorkspaceContext, WorkspaceEventHandler, WorkspaceEventKey, WorkspacePerformLayoutParams,
+    WorkspaceGroupParams, WorkspaceUngroupAllParams, WorkspaceUngroupSomeParams,
+    ProcessedTypeStyle, useWorkspace,
 } from './workspace/workspaceContext';
 export * from './workspace/workspaceLayout';
 export { WorkspaceRoot, WorkspaceRootProps } from './workspace/workspaceRoot';

--- a/src/workspace/workspaceContext.ts
+++ b/src/workspace/workspaceContext.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import type { ElementTypeIri } from '../data/model';
+import type { ElementIri, ElementTypeIri } from '../data/model';
 
 import type { CanvasApi } from '../diagram/canvasApi';
 import type { Element } from '../diagram/elements';
@@ -8,6 +8,7 @@ import type { LayoutFunction } from '../diagram/layout';
 import type { SharedCanvasState } from '../diagram/sharedCanvasState';
 
 import type { DataDiagramModel } from '../editor/dataDiagramModel';
+import type { EntityElement, EntityGroup } from '../editor/dataElements';
 import type { EditorController } from '../editor/editorController';
 import type { OverlayController } from '../editor/overlayController';
 
@@ -17,8 +18,14 @@ export interface WorkspaceContext {
     readonly editor: EditorController;
     readonly overlay: OverlayController;
     readonly disposeSignal: AbortSignal;
+
+    readonly getElementStyle: (element: Element) => ProcessedTypeStyle;
     readonly getElementTypeStyle: (types: ReadonlyArray<ElementTypeIri>) => ProcessedTypeStyle;
     readonly performLayout: (params: WorkspacePerformLayoutParams) => Promise<void>;
+    readonly group: (params: WorkspaceGroupParams) => Promise<EntityGroup>;
+    readonly ungroupAll: (params: WorkspaceUngroupAllParams) => Promise<EntityElement[]>;
+    readonly ungroupSome: (params: WorkspaceUngroupSomeParams) => Promise<EntityElement[]>;
+
     readonly triggerWorkspaceEvent: WorkspaceEventHandler;
 }
 
@@ -48,9 +55,52 @@ export interface WorkspacePerformLayoutParams {
      */
     animate?: boolean;
     /**
+     * Whether to fit elements into viewport after layout.
+     * 
+     * @default true
+     */
+    zoomToFit?: boolean;
+    /**
      * Signal to cancel computing and applying the layout.
      */
     signal?: AbortSignal;
+}
+
+export interface WorkspaceGroupParams {
+    /**
+     * Selected elements to group.
+     */
+    elements: ReadonlyArray<EntityElement>;
+    /**
+     * Target canvas to get element sizes from for animation.
+     */
+    canvas: CanvasApi;
+}
+
+export interface WorkspaceUngroupAllParams {
+    /**
+     * Selected groups to ungroup all entities from.
+     */
+    groups: ReadonlyArray<EntityGroup>;
+    /**
+     * Target canvas to get element sizes from for animation.
+     */
+    canvas: CanvasApi;
+}
+
+export interface WorkspaceUngroupSomeParams {
+    /**
+     * Selected group to ungroup some entities from.
+     */
+    group: EntityGroup;
+    /**
+     * Subset of entities to ungroup from the target group.
+     */
+    entities: ReadonlySet<ElementIri>;
+    /**
+     * Target canvas to get element sizes from for animation.
+     */
+    canvas: CanvasApi;
 }
 
 export type WorkspaceEventHandler = (key: WorkspaceEventKey) => void;

--- a/styles/templates/_standard.scss
+++ b/styles/templates/_standard.scss
@@ -1,21 +1,39 @@
 @import "../mixin/icons";
 
+$standard-template-background: #fafaf9;
+$standard-new-entity-stripe: white;
+
 .reactodia-standard-template {
   min-width: 180px;
   max-width: 400px;
   float: left;
 
+  &--group {
+    border-radius: 2px;
+    border: 1px solid;
+    border-color: var(--reactodia-standard-group-color);
+    background: $standard-template-background;
+    padding: 4px;
+  }
+
   &__main {
     border-radius: 2px;
     border: 1px solid;
+    border-color: var(--reactodia-standard-entity-color);
+    background-color: var(--reactodia-standard-entity-color);
   }
 
   &__body {
     margin-left: 8px;
     border-radius: 0 2px 2px 0;
     border-left: 1px solid;
+    border-left-color: var(--reactodia-standard-entity-color);
     padding: 3px 0;
-    background: #fafaf9;
+    background: $standard-template-background;
+  }
+
+  &--new &__main {
+    background-color: $standard-new-entity-stripe;
   }
 
   &__body-horizontal {
@@ -31,11 +49,56 @@
     margin-right: 12px;
   }
 
+  &__item {
+    display: flex;
+    border-radius: 2px;
+    border: 0px;
+
+    &:not(:first-child) {
+      margin-top: 4px;
+    }
+  }
+
+  &__item-stripe {
+    width: 6px;
+    background: var(--reactodia-standard-entity-color);
+  }
+
+  &--new &__item-stripe {
+    background: $standard-new-entity-stripe;
+    border: 1px solid var(--reactodia-standard-entity-color);
+  }
+
+  &__item-body {
+    flex: auto;
+    display: flex;
+    padding: 3px;
+    background: #fafaf9;
+  }
+
   &__label {
-    font-size: 19px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+
+  &--standalone &__label {
+    font-size: 19px;
+  }
+
+  &--group &__label {
+    font-size: 15px;
+    flex: auto;
+  }
+
+  &--group &--changed &__label {
+    font-style: italic;
+    color: rgb(0, 153, 255);
+  }
+
+  &--group &--deleted &__label {
+    text-decoration: line-through;
+    color: rgb(255, 59, 59);
   }
 
   &__thumbnail {
@@ -47,6 +110,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    color: var(--reactodia-standard-entity-color);
   }
 
   &__thumbnail-image {
@@ -62,6 +126,7 @@
 
   &__photo {
     border-bottom: 1px solid;
+    border-color: var(--reactodia-standard-entity-color);
   }
 
   &__photo-image {
@@ -124,7 +189,7 @@
     overflow-x: hidden;
   }
 
-  &__propertites-row {
+  &__properties-row {
     white-space: nowrap;
   }
 
@@ -153,14 +218,16 @@
 
   &__pinned-props {
     border-top: 1px solid;
+    border-color: var(--reactodia-standard-entity-color);
     margin: 0 5px;
   }
 
   &__dropdown {
+    border: 1px solid;
+    border-color: var(--reactodia-standard-entity-color);
     border-radius: 2px;
     background-color: white;
     margin-top: 5px;
-    border: 1px solid;
   }
 
   &__dropdown-content {
@@ -187,5 +254,23 @@
 
   &__edit-button {
     @include codicon-button("edit");
+  }
+
+  &__ungroup-one-button {
+    @include codicon-button("chevron-right");
+
+    width: 18px;
+    height: 18px;
+    padding: 0px;
+    align-self: center;
+
+    display: block;
+    opacity: 0;
+    transition: opacity 200ms 0ms;
+  }
+
+  &:hover &__ungroup-one-button,
+  &:focus &__ungroup-one-button {
+    opacity: 1;
   }
 }

--- a/styles/widgets/_selectionAction.scss
+++ b/styles/widgets/_selectionAction.scss
@@ -127,6 +127,14 @@
     background-image: url("@images/add-to-filter.svg");
   }
 
+  &__group {
+    background-image: url("@codicons/group-by-ref-type.svg");
+  }
+
+  &__ungroup {
+    background-image: url("@codicons/ungroup-by-ref-type.svg");
+  }
+
   &__establish-link {
     background-image: url("@codicons/plug.svg");
   }


### PR DESCRIPTION
* Add `EntityGroup` element type and `setEntityGroupItems` command;
* Add `DataDiagramModel.{group, ungroupAll, ungroupSome}` and `WorkspaceContext.{group, ungroupAll, ungroupSome}` methods to group and ungroup entities;
* Allow to skip "zoom to fit" in `WorkspaceContext.performLayout()` by passing `zoomToFit: false`;
* Allow to have multiple `RelationLink`s between same elements as long as the relation key (`data`) is different;
* Include `sourceIri` and `targetIri` when serializing `RelationLink` (required to restore entity groups);
* Update `StandardTemplate` to display entity groups;
* Add `SelectionActionGroup` to group/ungroup from `Halo` and `Selection`, update default actions and its dock placement;
* Fix `RenderingState.syncUpdate()` not updating element sizes when called from React-managed handlers due to batching;