### PR TITLE
Add `filterOnlyLanguages` option to `SparqlDataProviderSettings` to fetch labels and property values only in specified languages

### DIFF
--- a/examples/wikidata.tsx
+++ b/examples/wikidata.tsx
@@ -24,6 +24,7 @@ function WikidataExample() {
             },
             {
                 ...Reactodia.WikidataSettings,
+                filterOnlyLanguages: ['de', 'en', 'es', 'ru', 'zh'],
                 // Public Wikidata endpoint is too overloaded for the connection statistics
                 linkTypesStatisticsQuery: '',
             });
@@ -66,10 +67,6 @@ function WikidataExample() {
                         {code: 'de', label: 'Deutsch'},
                         {code: 'en', label: 'english'},
                         {code: 'es', label: 'español'},
-                        {code: 'fr', label: 'français'},
-                        {code: 'ja', label: '日本語'},
-                        {code: 'hi', label: 'हिन्दी'},
-                        {code: 'pt', label: 'português'},
                         {code: 'ru', label: 'русский'},
                         {code: 'zh', label: '汉语'},
                     ],


### PR DESCRIPTION
* Fix `WikidataSettings` for `SparqlDataProvider` to resolve property type labels;
* Reduce language count in Wikidata example to decrease the load on public Wikidata instance;