### PR TITLE
Expose `OverlayController.startTask()` method to start foreground canvas tasks

### DIFF
--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -102,7 +102,8 @@ export {
     subscribeElementTypes, subscribeLinkTypes, subscribePropertyTypes,
 } from './editor/observedElement';
 export {
-    OverlayController, OverlayControllerEvents, PropertyEditor, PropertyEditorOptions,
+    OverlayController, OverlayControllerEvents, OverlayTask,
+    PropertyEditor, PropertyEditorOptions,
 } from './editor/overlayController';
 export { ValidationState, ElementValidation, LinkValidation } from './editor/validation';
 export { WithFetchStatus, WithFetchStatusProps } from './editor/withFetchStatus';


### PR DESCRIPTION
* Display overlay task while computing graph layout via `WorkspaceContext.performLayout()`;