### PR TITLE
Refactor and document exported library API

### DIFF
--- a/examples/basic.tsx
+++ b/examples/basic.tsx
@@ -28,7 +28,7 @@ function BasicExample() {
         for (const {element} of await dataProvider.lookup({elementTypeId})) {
             model.createElement(element);
         }
-        await model.requestLinksOfType();
+        await model.requestLinks();
 
         // Layout elements on canvas
         await performLayout({signal});

--- a/examples/rdf.tsx
+++ b/examples/rdf.tsx
@@ -35,6 +35,8 @@ function RdfExample() {
 
     const [metadataApi] = React.useState(() => new ExampleMetadataApi());
     const [validationApi] = React.useState(() => new ExampleValidationApi());
+    const [renameLinkHandler] = React.useState(() => new RenameSubclassOfHandler());
+
     const suggestProperties = React.useCallback<Reactodia.PropertySuggestionHandler>(params => {
         let maxLength = 0;
         for (const iri of params.properties) {
@@ -52,6 +54,7 @@ function RdfExample() {
             defaultLayout={defaultLayout}
             metadataApi={metadataApi}
             validationApi={validationApi}
+            renameLinkHandler={renameLinkHandler}
             typeStyleResolver={Reactodia.SemanticTypeStyles}
             onIriClick={({iri}) => window.open(iri)}>
             <Reactodia.DefaultWorkspace
@@ -64,10 +67,7 @@ function RdfExample() {
                     },
                     linkTemplateResolver: type => {
                         if (type === 'http://www.w3.org/2000/01/rdf-schema#subClassOf') {
-                            return {
-                                ...Reactodia.DefaultLinkTemplate,
-                                editableLabel: EDITABLE_LINK_LABEL,
-                            };
+                            return Reactodia.DefaultLinkTemplate;
                         }
                         return Reactodia.OntologyLinkTemplates(type); 
                     },
@@ -84,28 +84,11 @@ function RdfExample() {
     );
 }
 
-const CUSTOM_LINK_LABEL_IRI = 'urn:example:custom-link-label';
-const EDITABLE_LINK_LABEL: Reactodia.EditableLinkLabel = {
-    getLabel: link => {
-        const {linkState} = link;
-        if (
-            linkState &&
-            Object.prototype.hasOwnProperty.call(linkState, CUSTOM_LINK_LABEL_IRI)
-        ) {
-            const customLabel = linkState[CUSTOM_LINK_LABEL_IRI];
-            if (typeof customLabel === 'string') {
-                return customLabel;
-            }
-        }
-        return undefined;
-    },
-    setLabel: (link, label) => {
-        link.setLinkState({
-            ...link.linkState,
-            [CUSTOM_LINK_LABEL_IRI]: label.length === 0 ? undefined : label,
-        });
-    },
-};
+class RenameSubclassOfHandler extends Reactodia.RenameLinkToLinkStateHandler {
+    canRename(link: Reactodia.Link): boolean {
+        return link.typeId === 'http://www.w3.org/2000/01/rdf-schema#subClassOf';
+    }
+}
 
 interface ToolbarActionOpenTurtleGraphProps {
     onOpen: (turtleText: string) => void;

--- a/examples/stressTest.tsx
+++ b/examples/stressTest.tsx
@@ -42,7 +42,7 @@ function StressTestExample() {
             batch.store();
             await Promise.all([
                 model.requestElementData(nodes),
-                model.requestLinksOfType(),
+                model.requestLinks(),
             ]);
             model.history.reset();
 

--- a/src/coreUtils/async.ts
+++ b/src/coreUtils/async.ts
@@ -1,4 +1,7 @@
 /**
+ * Transforms `Promise` in such a way that resolved or rejected results
+ * are mapped to `null` if specified abort `signal` is aborted.
+ *
  * @category Utilities
  */
 export function mapAbortedToNull<T>(
@@ -102,6 +105,10 @@ export async function raceHappyEyes<T, R>(
 }
 
 /**
+ * Creates a derived abort signal, i.e. `AbortSignal` instance
+ * which is automatically aborted when parent signal is aborted,
+ * but can be aborted separately the same way as normal `AbortController`.
+ *
  * @category Utilities
  */
 export class AbortScope {
@@ -135,6 +142,11 @@ export class AbortScope {
 }
 
 /**
+ * Waits a specified timeout in milliseconds the resolves the result promise.
+ *
+ * Can be cancelled via specified `AbortSignal`, in which case the promise
+ * will be rejected with abort signal reason (an error with `name === "AbortError"`).
+ *
  * @category Utilities
  */
 export function delay(timeout: number, options?: { signal?: AbortSignal }): Promise<void> {

--- a/src/coreUtils/collections.ts
+++ b/src/coreUtils/collections.ts
@@ -33,6 +33,9 @@ export function multimapDelete<K, V>(map: BasicMap<K, Set<V>>, key: K, value: V)
 }
 
 /**
+ * Returns `true` if two arrays has equal elements (compared via `===`)
+ * and in the same order, otherwise returns `false`.
+ *
  * @category Utilities
  */
 export function shallowArrayEqual<T>(a: ReadonlyArray<T>, b: ReadonlyArray<T>): boolean {
@@ -83,6 +86,10 @@ export class OrderedMap<V> {
 }
 
 /**
+ * Makes a sorting comparator (a function to pass to `Array.sort()`) which
+ * moves specified subset of items either to the beginning of the array
+ * or to the end.
+ *
  * @category Utilities
  */
 export function moveComparator<T>(

--- a/src/coreUtils/events.ts
+++ b/src/coreUtils/events.ts
@@ -1,19 +1,51 @@
+/**
+ * Event listener callback for a specific event type.
+ *
+ * @see Events.on()
+ */
 export type Listener<Data, Key extends keyof Data> = (data: Data[Key]) => void;
+/**
+ * Event listener callback for all event types.
+ *
+ * @see Events.onAny()
+ */
 export type AnyListener<Data> = (data: Partial<Data>) => void;
 /** @hidden */
 export type Unsubscribe = () => void;
 
+/**
+ * Event data for a property change event, i.e. event which is raised
+ * when some property value changes to another.
+ */
 export interface PropertyChange<Source, Value> {
+    /**
+     * Event source (the object owning the property).
+     */
     readonly source: Source;
+    /**
+     * Previous value for a property which has changed.
+     */
     readonly previous: Value;
 }
 
+/**
+ * Event data for combined (all) event types.
+ *
+ * @see Events.onAny()
+ */
 export interface AnyEvent<Data> {
     readonly data: Partial<Data>;
 }
 
 /**
+ * Defines an observable object with one or many event types to subscribe to.
+ *
+ * `Data` type variable is expected to be an interface type, where each property
+ * is an event type and its value type is event data.
+ *
  * @category Core
+ * @see EventTrigger
+ * @see EventSource
  */
 export interface Events<out Data> {
     on<Key extends keyof Data>(eventKey: Key, listener: Listener<Data, Key>): void;
@@ -23,13 +55,38 @@ export interface Events<out Data> {
 }
 
 /**
+ * Defines an event emitter which can trigger one or many event types.
+ *
+ * `Data` type variable is expected to be an interface type, where each property
+ * is an event type and its value type is event data.
+ * 
  * @category Core
+ * @see Events
+ * @see EventSource
  */
 export interface EventTrigger<in Data> {
     trigger<Key extends keyof Data>(eventKey: Key, data: Data[Key]): void;
 }
 
 /**
+ * Implements an event bus, exposing both an observable object (`Events`) and
+ * event emitter (`EventTrigger`) sides.
+ *
+ * **Example**:
+ * ```ts
+ * interface CollectionEvents {
+ *     addItem: AddItemEvent;
+ *     removeItem: RemoveItemEvent;
+ * }
+ * 
+ * const source = new EventSource<CollectionEvents>();
+ * const events: Events<CollectionEvents> = source;
+ * 
+ * events.on('addItem', e => { ... });
+ *
+ * source.trigger('addItem', { item: someItem });
+ * ```
+ * 
  * @category Core
  */
 export class EventSource<Data> implements Events<Data>, EventTrigger<Data> {
@@ -85,7 +142,11 @@ export class EventSource<Data> implements Events<Data>, EventTrigger<Data> {
 }
 
 /**
+ * Provides a convenient way to subscribe to one or many observable objects
+ * and unsubscribe from all of them at once.
+ * 
  * @category Core
+ * @see Events
  */
 export class EventObserver {
     private onDispose = new Set<Unsubscribe>();

--- a/src/coreUtils/hashMap.ts
+++ b/src/coreUtils/hashMap.ts
@@ -15,6 +15,9 @@ export interface ReadonlyHashSet<K> extends ReadonlySet<K> {
 type Bucket<K, V> = { readonly k: K; readonly v: V } | Array<{ readonly k: K; readonly v: V }>;
 
 /**
+ * Implements a basic hash map data structure with ability to pass custom hash
+ * and equality comparison functions.
+ *
  * @category Utilities
  */
 export class HashMap<K, V> implements ReadonlyMap<K, V> {
@@ -173,6 +176,9 @@ export class HashMap<K, V> implements ReadonlyMap<K, V> {
 }
 
 /**
+ * Implements a basic hash set data structure with ability to pass custom hash
+ * and equality comparison functions.
+ *
  * @category Utilities
  */
 export class HashSet<K> implements ReadonlyHashSet<K> {

--- a/src/coreUtils/hooks.ts
+++ b/src/coreUtils/hooks.ts
@@ -11,7 +11,11 @@ import type { Events } from './events';
 export type SyncStore = (onChange: () => void) => (() => void);
 
 /**
+ * Subscribes to a value which changes are tracked by the specified event.
+ *
  * @category Hooks
+ * @see useEventStore()
+ * @see useSyncStore()
  */
 export function useObservedProperty<E, K extends keyof E, R>(
     events: Events<E>,
@@ -26,6 +30,8 @@ const NEVER_SYNC_STORE_DISPOSE = (): void => {};
 const NEVER_SYNC_STORE: SyncStore = () => NEVER_SYNC_STORE_DISPOSE;
 
 /**
+ * An event store that never triggers any change.
+ *
  * @category Utility
  */
 export function neverSyncStore(): SyncStore {
@@ -33,6 +39,8 @@ export function neverSyncStore(): SyncStore {
 }
 
 /**
+ * Creates an event store which changes when an event triggers with the specified event type.
+ *
  * @category Hooks
  */
 export function useEventStore<E, K extends keyof E>(events: Events<E> | undefined, key: K): SyncStore {
@@ -47,6 +55,9 @@ export function useEventStore<E, K extends keyof E>(events: Events<E> | undefine
 }
 
 /**
+ * Transforms event store in a way that the result store debounces the changes
+ * until the next rendered frame (via `requestAnimationFrame()`).
+ *
  * @category Hooks
  */
 export function useFrameDebouncedStore(subscribe: SyncStore): SyncStore {

--- a/src/coreUtils/keyedObserver.ts
+++ b/src/coreUtils/keyedObserver.ts
@@ -52,6 +52,11 @@ export class KeyedObserver<Key extends string> {
  *
  * This store is similar to one accepted by `React.useSyncEventStore()` hook
  * but accepted by `useKeyedSyncStore()` instead.
+ *
+ * Arbitrary `context` value can be made required by the store which is captured
+ * on the initial subscription and its changes does not force a re-subscription.
+ *
+ * @see useKeyedSyncStore()
  */
 export type KeyedSyncStore<K, Context> = (
     key: K,
@@ -60,6 +65,8 @@ export type KeyedSyncStore<K, Context> = (
 ) => () => void;
 
 /**
+ * Same as `React.useSyncExternalStore()` but for `KeyedSyncStore`.
+ *
  * @category Hooks
  */
 export function useKeyedSyncStore<K extends string, Context>(

--- a/src/coreUtils/scheduler.ts
+++ b/src/coreUtils/scheduler.ts
@@ -1,4 +1,10 @@
 /**
+ * Debounces a function call such that only one is performed if multiple
+ * requests are made since initial one for the waiting time.
+ *
+ * If `waitingTime` is 0, then the timeout is assumed to be up until next
+ * rendered frame (via `requestAnimationFrame()`).
+ *
  * @category Utilities
  */
 export class Debouncer {
@@ -91,6 +97,9 @@ export class BufferingQueue<Key extends string> {
 }
 
 /**
+ * Runs specified callback on each rendered frame for the `duration` interval
+ * using `requestAnimationFrame()`.
+ *
  * @category Utilities
  */
 export function animateInterval(

--- a/src/coreUtils/workers.ts
+++ b/src/coreUtils/workers.ts
@@ -3,7 +3,23 @@ import * as React from 'react';
 import type { WorkerCall, WorkerCallSuccess, WorkerCallError, WorkerConstructor } from '../worker-protocol';
 
 /**
+ * Creates a ref-counted Web Worker definition.
+ *
+ * The worker module should follow a specific communication protocol,
+ * defined by `@reactodia/workspace/worker-protocol` module.
+ *
+ * **Example**:
+ * ```
+ * const worker = defineWorker(() => new Worker('./worker.js'), []);
+ * 
+ * function Component() {
+ *   const instance = useWorker(worker);
+ *   ...
+ * }
+ * ```
+ *
  * @category Utilities
+ * @see useWorker()
  */
 export function defineWorker<T extends WorkerConstructor<unknown[], unknown>>(
     workerFactory: () => Worker,
@@ -36,7 +52,13 @@ interface RefCountedWorkerState<T> {
 }
 
 /**
+ * Gets a shared instance of the defined worker.
+ *
+ * The worker instance will be created on the first call and
+ * disposed when the last component using the hook is unmounted.
+ *
  * @category Hooks
+ * @see defineWorker()
  */
 export function useWorker<T>(worker: WorkerDefinition<T>): T {
     React.useEffect(() => {

--- a/src/data/composite/composite.ts
+++ b/src/data/composite/composite.ts
@@ -1,8 +1,10 @@
 import * as Rdf from '../rdf/rdfModel';
-import { DataProvider, DataProviderLookupParams } from '../provider';
 import {
-    ElementTypeModel, ElementTypeGraph, LinkTypeModel, ElementModel, LinkModel, LinkCount, PropertyTypeModel,
-    ElementIri, ElementTypeIri, LinkTypeIri, PropertyTypeIri, LinkedElement,
+    DataProvider, DataProviderLinkCount, DataProviderLookupParams, DataProviderLookupItem,
+} from '../provider';
+import {
+    ElementTypeModel, ElementTypeGraph, LinkTypeModel, ElementModel, LinkModel, PropertyTypeModel,
+    ElementIri, ElementTypeIri, LinkTypeIri, PropertyTypeIri,
 } from '../model';
 import {
     CompositeResponse,
@@ -17,16 +19,37 @@ import {
     mergeLookup,
 } from './mergeUtils';
 
+/**
+ * Options for `CompositeDataProvider`.
+ *
+ * @see CompositeDataProvider
+ */
 export interface CompositeDataProviderOptions {
+    /**
+     * Base data providers to combine result data from.
+     */
     providers: ReadonlyArray<DataProviderDefinition>;
 }
 
+/**
+ * Combined data provider definition.
+ *
+ * @see CompositeDataProvider
+ */
 export interface DataProviderDefinition {
+    /**
+     * Provider name to assist in debugging.
+     */
     readonly name: string;
+    /**
+     * Data provider to combine data from.
+     */
     readonly provider: DataProvider;
 }
 
 /**
+ * Provides graph data by combining results from multiple other data providers.
+ *
  * @category Data
  */
 export class CompositeDataProvider implements DataProvider {
@@ -108,11 +131,11 @@ export class CompositeDataProvider implements DataProvider {
         elementId: ElementIri;
         inexactCount?: boolean;
         signal?: AbortSignal;
-    }): Promise<LinkCount[]> {
+    }): Promise<DataProviderLinkCount[]> {
         return this.requestWithMerge(p => p.connectedLinkStats(params), mergeConnectedLinkStats);
     }
 
-    lookup(params: DataProviderLookupParams): Promise<LinkedElement[]> {
+    lookup(params: DataProviderLookupParams): Promise<DataProviderLookupItem[]> {
         return this.requestWithMerge(p => p.lookup(params), mergeLookup);
     }
 }

--- a/src/data/composite/mergeUtils.ts
+++ b/src/data/composite/mergeUtils.ts
@@ -2,10 +2,11 @@ import { HashSet } from '../../coreUtils/hashMap';
 
 import * as Rdf from '../rdf/rdfModel';
 import {
-    ElementTypeModel, ElementTypeGraph, LinkTypeModel, ElementModel, LinkModel, LinkCount,
-    PropertyTypeIri, PropertyTypeModel, ElementIri, ElementTypeIri, LinkTypeIri, LinkedElement,
+    ElementTypeModel, ElementTypeGraph, LinkTypeModel, ElementModel, LinkModel,
+    PropertyTypeIri, PropertyTypeModel, ElementIri, ElementTypeIri, LinkTypeIri,
     hashLink, equalLinks, hashSubtypeEdge, equalSubtypeEdges,
 } from '../model';
+import type { DataProviderLinkCount, DataProviderLookupItem } from '../provider';
 import type { DataProviderDefinition } from './composite';
 
 const DATA_PROVIDER_PROPERTY = 'urn:reactodia:sourceProvider';
@@ -182,8 +183,10 @@ export function mergeLinksInfo(responses: CompositeResponse<LinkModel[]>[]): Lin
     return result;
 }
 
-export function mergeConnectedLinkStats(responses: CompositeResponse<LinkCount[]>[]): LinkCount[] {
-    const result = new Map<LinkTypeIri, LinkCount>();
+export function mergeConnectedLinkStats(
+    responses: CompositeResponse<DataProviderLinkCount[]>[]
+): DataProviderLinkCount[] {
+    const result = new Map<LinkTypeIri, DataProviderLinkCount>();
     for (const [response] of responses) {
         for (const model of response) {
             const existing = result.get(model.id);
@@ -193,7 +196,7 @@ export function mergeConnectedLinkStats(responses: CompositeResponse<LinkCount[]
     return Array.from(result.values());
 }
 
-function mergeLinkCount(a: LinkCount, b: LinkCount): LinkCount {
+function mergeLinkCount(a: DataProviderLinkCount, b: DataProviderLinkCount): DataProviderLinkCount {
     return {
         ...a,
         ...b,
@@ -203,14 +206,16 @@ function mergeLinkCount(a: LinkCount, b: LinkCount): LinkCount {
     };
 }
 
-interface MutableLinkedElement {
+interface MutableLookupItem {
     element: ElementModel;
     inLinks: Set<LinkTypeIri>;
     outLinks: Set<LinkTypeIri>;
 }
 
-export function mergeLookup(responses: CompositeResponse<LinkedElement[]>[]): LinkedElement[] {
-    const linkedElements = new Map<ElementIri, MutableLinkedElement>();
+export function mergeLookup(
+    responses: CompositeResponse<DataProviderLookupItem[]>[]
+): DataProviderLookupItem[] {
+    const linkedElements = new Map<ElementIri, MutableLookupItem>();
     for (const [response, provider] of responses) {
         for (const {element: baseElement, inLinks, outLinks} of response) {
             const element: ElementModel = {

--- a/src/data/decorated/decoratedDataProvider.ts
+++ b/src/data/decorated/decoratedDataProvider.ts
@@ -1,17 +1,35 @@
 import { delay } from '../../coreUtils/async';
 
 import type * as Rdf from '../rdf/rdfModel';
-import { DataProvider, DataProviderLookupParams } from '../provider';
 import {
-    ElementTypeModel, ElementTypeGraph, LinkTypeModel, ElementModel, LinkModel, LinkCount,
-    ElementIri, ElementTypeIri, LinkTypeIri, PropertyTypeIri, PropertyTypeModel, LinkedElement,
+    DataProvider, DataProviderLinkCount, DataProviderLookupParams, DataProviderLookupItem,
+} from '../provider';
+import {
+    ElementTypeModel, ElementTypeGraph, LinkTypeModel, ElementModel, LinkModel,
+    ElementIri, ElementTypeIri, LinkTypeIri, PropertyTypeIri, PropertyTypeModel,
 } from '../model';
 
+/**
+ * Options for `DecoratedDataProvider`.
+ *
+ * @see DecoratedDataProvider
+ */
 export interface DecoratedDataProviderOptions {
+    /**
+     * Base data provider to decorate.
+     */
     readonly baseProvider: DataProvider;
+    /**
+     * Callback which decorates requests to the base data provider.
+     */
     readonly decorator: DataProviderDecorator;
 }
 
+/**
+ * Known data provider operation names.
+ *
+ * @see DecoratedDataProvider
+ */
 export type DecoratedMethodName =
     | 'knownElementTypes'
     | 'knownLinkTypes'
@@ -23,6 +41,11 @@ export type DecoratedMethodName =
     | 'connectedLinkStats'
     | 'lookup';
 
+/**
+ * Callback to pass-through or alter requests to a data provider.
+ *
+ * @see DecoratedDataProvider
+ */
 export type DataProviderDecorator = <P extends { signal?: AbortSignal }, R>(
     method: DecoratedMethodName,
     params: P,
@@ -30,6 +53,9 @@ export type DataProviderDecorator = <P extends { signal?: AbortSignal }, R>(
 ) => Promise<R>;
 
 /**
+ * Utility graph data provider to wrap over another provider to modify
+ * how the requests are made or alter the results.
+ *
  * @category Data
  */
 export class DecoratedDataProvider implements DataProvider {
@@ -107,11 +133,11 @@ export class DecoratedDataProvider implements DataProvider {
         elementId: ElementIri;
         inexactCount?: boolean;
         signal?: AbortSignal;
-    }): Promise<LinkCount[]> {
+    }): Promise<DataProviderLinkCount[]> {
         return this.decorate('connectedLinkStats', [params]);
     }
 
-    lookup(params: DataProviderLookupParams): Promise<LinkedElement[]> {
+    lookup(params: DataProviderLookupParams): Promise<DataProviderLookupItem[]> {
         return this.decorate('lookup', [params]);
     }
 }

--- a/src/data/decorated/emptyDataProvider.ts
+++ b/src/data/decorated/emptyDataProvider.ts
@@ -1,11 +1,15 @@
 import {
     ElementTypeGraph, LinkTypeModel, ElementTypeIri, ElementTypeModel, PropertyTypeIri, PropertyTypeModel,
-    LinkTypeIri, ElementIri, ElementModel, LinkModel, LinkCount, LinkedElement,
+    LinkTypeIri, ElementIri, ElementModel, LinkModel,
 } from '../model';
-import { DataProvider, DataProviderLookupParams } from '../provider';
+import {
+    DataProvider, DataProviderLinkCount, DataProviderLookupParams, DataProviderLookupItem,
+} from '../provider';
 import { DataFactory, DefaultDataFactory } from '../rdf/rdfModel';
 
 /**
+ * Empty graph data provider, which always return nothing.
+ *
  * @category Data
  */
 export class EmptyDataProvider implements DataProvider {
@@ -68,11 +72,11 @@ export class EmptyDataProvider implements DataProvider {
         elementId: ElementIri;
         inexactCount?: boolean | undefined;
         signal?: AbortSignal | undefined;
-    }): Promise<LinkCount[]> {
+    }): Promise<DataProviderLinkCount[]> {
         return Promise.resolve([]);
     }
 
-    lookup(params: DataProviderLookupParams): Promise<LinkedElement[]> {
+    lookup(params: DataProviderLookupParams): Promise<DataProviderLookupItem[]> {
         return Promise.resolve([]);
     }
 }

--- a/src/data/metadataApi.ts
+++ b/src/data/metadataApi.ts
@@ -1,6 +1,11 @@
 import { ElementModel, ElementTypeIri, LinkTypeIri, PropertyTypeIri, LinkModel, LinkDirection } from './model';
 
 /**
+ * Provides a strategy to visual graph authoring: which parts of the graph
+ * are editable and what is the range of possible values to allow.
+ *
+ * **Experimental**: this feature will likely change in the future.
+ *
  * @category Core
  */
 export interface MetadataApi {

--- a/src/data/model.ts
+++ b/src/data/model.ts
@@ -4,15 +4,15 @@ import { hashFnv32a } from '../data/utils';
 import * as Rdf from './rdf/rdfModel';
 
 /**
- * Nominal (branded) type for element IRI, i.e. unique ID string.
+ * Nominal (branded) type for element (graph node) IRI, i.e. unique ID string.
  */
 export type ElementIri = string & { readonly elementBrand: void };
 /**
- * Nominal (branded) type for element type IRI, i.e. unique ID string.
+ * Nominal (branded) type for element (graph node) type IRI, i.e. unique ID string.
  */
 export type ElementTypeIri = string & { readonly classBrand: void };
 /**
- * Nominal (branded) type for link type IRI, i.e. unique ID string.
+ * Nominal (branded) type for link (graph edge) type IRI, i.e. unique ID string.
  */
 export type LinkTypeIri = string & { readonly linkTypeBrand: void };
 /**
@@ -20,6 +20,9 @@ export type LinkTypeIri = string & { readonly linkTypeBrand: void };
  */
 export type PropertyTypeIri = string & { readonly propertyTypeBrand: void };
 
+/**
+ * Link (graph edge) direction: `in` for incoming, `out` for outgoing.
+ */
 export type LinkDirection = 'in' | 'out';
 
 /**
@@ -34,11 +37,16 @@ export interface ElementTypeGraph {
 }
 
 /**
+ * "Subtype of" relation between derived element type and its base type.
+ *
  * @category Data
+ * @see ElementTypeGraph
  */
 export type SubtypeEdge = readonly [ElementTypeIri, ElementTypeIri];
 
 /**
+ * Element (graph node) data.
+ *
  * @category Data
  */
 export interface ElementModel {
@@ -50,6 +58,8 @@ export interface ElementModel {
 }
 
 /**
+ * A `{source, target, type}` tuple which uniquely identifies a link (graph edge).
+ *
  * @category Data
  */
 export interface LinkKey {
@@ -59,6 +69,8 @@ export interface LinkKey {
 }
 
 /**
+ * Link (graph edge) data.
+ *
  * @category Data
  */
 export interface LinkModel {
@@ -69,6 +81,8 @@ export interface LinkModel {
 }
 
 /**
+ * Element (graph node) type data.
+ *
  * @category Data
  */
 export interface ElementTypeModel {
@@ -78,6 +92,8 @@ export interface ElementTypeModel {
 }
 
 /**
+ * Link (graph edge) type data.
+ *
  * @category Data
  */
 export interface LinkTypeModel {
@@ -87,6 +103,8 @@ export interface LinkTypeModel {
 }
 
 /**
+ * Property type data.
+ *
  * @category Data
  */
 export interface PropertyTypeModel {
@@ -95,32 +113,16 @@ export interface PropertyTypeModel {
 }
 
 /**
- * @category Data
- */
-export interface LinkCount {
-    readonly id: LinkTypeIri;
-    readonly inCount: number;
-    readonly outCount: number;
-    /**
-     * If `true`, then `inCount` and `outCount` values might be not exact
-     * in case when the values are non-zero.
-     */
-    readonly inexact?: boolean;
-}
-
-/**
- * Describes an element with information on which link types and directions
- * are used to connect it to other elements.
+ * Returns `true` if IRI represents an anonymous entity specific to the data provider;
+ * otherwise `false`.
  *
- * @category Data
- */
-export interface LinkedElement {
-    readonly element: ElementModel;
-    readonly inLinks: ReadonlySet<LinkTypeIri>;
-    readonly outLinks: ReadonlySet<LinkTypeIri>;
-}
-
-/**
+ * The represented entity can only be decoded by a `DataProvider` with a support
+ * for the specific blank node subtype, determined by the IRI prefix, e.g.:
+ *   - `urn:reactodia:blank:rdf:*` encodes RDF blank nodes from `RdfDataProvider;
+ *   - `urn:reactodia:blank:sparql:*` encodes outer graph content for blank nodes
+ *     from `SparqlDataProvider`;
+ *   - etc.
+ *
  * @category Data
  */
 export function isEncodedBlank(iri: string): boolean {
@@ -128,6 +130,8 @@ export function isEncodedBlank(iri: string): boolean {
 }
 
 /**
+ * Computes a hash code for `SubtypeEdge` value.
+ *
  * @category Data
  */
 export function hashSubtypeEdge(edge: SubtypeEdge): number {
@@ -138,6 +142,8 @@ export function hashSubtypeEdge(edge: SubtypeEdge): number {
 }
 
 /**
+ * Computes whether `SubtypeEdges` values are the same.
+ *
  * @category Data
  */
 export function equalSubtypeEdges(a: SubtypeEdge, b: SubtypeEdge): boolean {
@@ -147,6 +153,8 @@ export function equalSubtypeEdges(a: SubtypeEdge, b: SubtypeEdge): boolean {
 }
 
 /**
+ * Computes whether `LinkKey` values are the same.
+ *
  * @category Data
  */
 export function equalLinks(left: LinkKey, right: LinkKey) {
@@ -158,6 +166,8 @@ export function equalLinks(left: LinkKey, right: LinkKey) {
 }
 
 /**
+ * Computes a hash code for `LinkKey` value.
+ *
  * @category Data
  */
 export function hashLink(link: LinkKey): number {
@@ -169,6 +179,8 @@ export function hashLink(link: LinkKey): number {
 }
 
 /**
+ * Computes whether `ElementModel` values are the same, including property values.
+ *
  * @category Data
  */
 export function equalElements(a: ElementModel, b: ElementModel): boolean {

--- a/src/data/rdf/memoryDataset.ts
+++ b/src/data/rdf/memoryDataset.ts
@@ -5,6 +5,8 @@ import {
 } from './rdfModel';
 
 /**
+ * In-memory [RDF quad dataset](https://rdf.js.org/dataset-spec/).
+ *
  * @category Utilities
  */
 export interface MemoryDataset extends Iterable<Quad> {
@@ -29,6 +31,9 @@ export interface MemoryDataset extends Iterable<Quad> {
     forEach(callback: (t: Quad) => void): void;
 }
 
+/**
+ * Bit-flags for dataset indexing modes.
+ */
 export enum IndexQuadBy {
     /** Index by whole quad (default, required). */
     OnlyQuad = 0,
@@ -47,6 +52,9 @@ export enum IndexQuadBy {
 }
 
 /**
+ * Creates an empty mutable in-memory RDF quad dataset,
+ * with optional simple indexes on quad sub-parts (subject, predicate, object).
+ *
  * @category Utilities
  */
 export function indexedDataset(indexBy: IndexQuadBy): MemoryDataset {

--- a/src/data/rdf/rdfDataProvider.ts
+++ b/src/data/rdf/rdfDataProvider.ts
@@ -1,15 +1,22 @@
 import { HashMap, HashSet } from '../../coreUtils/hashMap';
 
 import {
-    ElementTypeModel, ElementTypeGraph, LinkTypeModel, ElementModel, LinkModel, LinkCount, PropertyTypeModel,
-    ElementIri, ElementTypeIri, LinkTypeIri, PropertyTypeIri, SubtypeEdge, LinkedElement,
+    ElementTypeGraph, ElementTypeModel, LinkTypeModel, ElementModel, LinkModel, PropertyTypeModel,
+    ElementIri, ElementTypeIri, LinkTypeIri, PropertyTypeIri, SubtypeEdge,
     hashSubtypeEdge, equalSubtypeEdges,
 } from '../model';
-import { DataProvider, DataProviderLookupParams } from '../provider';
+import {
+    DataProvider, DataProviderLinkCount, DataProviderLookupParams, DataProviderLookupItem,
+} from '../provider';
 
 import { MemoryDataset, IndexQuadBy, indexedDataset } from './memoryDataset';
 import * as Rdf from './rdfModel';
 
+/**
+ * Options for `RdfDataProvider`.
+ *
+ * @see RdfDataProvider
+ */
 export interface RdfDataProviderOptions {
     /**
      * Whether to support blank node terms when accessing the data.
@@ -75,6 +82,8 @@ const RDFS_SUB_CLASS_OF = 'http://www.w3.org/2000/01/rdf-schema#subClassOf';
 const SCHEMA_THUMBNAIL_URL = 'https://schema.org/thumbnailUrl';
 
 /**
+ * Provides graph data from in-memory RDF quad dataset.
+ *
  * @category Data
  */
 export class RdfDataProvider implements DataProvider {
@@ -353,7 +362,7 @@ export class RdfDataProvider implements DataProvider {
         elementId: ElementIri;
         inexactCount?: boolean;
         signal?: AbortSignal;
-    }): Promise<LinkCount[]> {
+    }): Promise<DataProviderLinkCount[]> {
         const {elementId} = params;
         const elementIri = this.decodeTerm(elementId);
         
@@ -373,7 +382,7 @@ export class RdfDataProvider implements DataProvider {
             }
         }
 
-        const counts: LinkCount[] = [];
+        const counts: DataProviderLinkCount[] = [];
         for (const [linkTypeId, outCount] of outCounts) {
             counts.push({
                 id: linkTypeId,
@@ -394,7 +403,7 @@ export class RdfDataProvider implements DataProvider {
         return Promise.resolve(counts);
     }
 
-    lookup(params: DataProviderLookupParams): Promise<LinkedElement[]> {
+    lookup(params: DataProviderLookupParams): Promise<DataProviderLookupItem[]> {
         interface ResultItem {
             readonly term: Rdf.NamedNode | Rdf.BlankNode;
             outLinks?: Set<LinkTypeIri>;
@@ -474,7 +483,7 @@ export class RdfDataProvider implements DataProvider {
             requiredTextFilter = undefined;
         }
 
-        const linkedElements: LinkedElement[] = [];
+        const linkedElements: DataProviderLookupItem[] = [];
         const limit = typeof params.limit === 'number' ? params.limit : Number.POSITIVE_INFINITY;
         for (const item of items.values()) {
             if (linkedElements.length >= limit) {

--- a/src/data/rdf/rdfEscape.ts
+++ b/src/data/rdf/rdfEscape.ts
@@ -1,6 +1,5 @@
 // Adopted from N3.js by Ruben Verborgh: https://github.com/rdfjs/N3.js
 // https://github.com/rdfjs/N3.js/blob/208aef00342a7fe2031352aef45cff9a9eb261b8/src/N3Writer.js
-
 export function escapeRdfValue(value: string): string {
     return ESCAPE_TEST.test(value) ? value.replace(ESCAPE_TARGETS, escapeReplacer) : value;
 }
@@ -18,7 +17,7 @@ const ESCAPED_CHARACTERS: { [str: string]: string | undefined } = {
 };
 
 /**
- * Replaces a character by its escaped version
+ * Replaces a character by its escaped version in string literals for the N3 format.
  */
 function escapeReplacer(character: string) {
     // Replace a single character by its escaped version

--- a/src/data/schema.ts
+++ b/src/data/schema.ts
@@ -24,16 +24,44 @@ export namespace GenerateID {
 }
 
 /**
+ * Well-known properties for element state (`Element.elementState`)
+ * or link state (`Link.linkState`).
+ *
  * @category Constants
  */
 export namespace TemplateProperties {
+    /**
+     * Element state property to mark some element data properties as "pinned",
+     * i.e. displayed even if element is collapsed.
+     *
+     * @see PinnedProperties
+     */
     export const PinnedProperties = 'urn:reactodia:pinnedProperties';
+    /**
+     * Link state property to change to name of a specific link only on the diagram
+     * (instead of displaying link type label).
+     */
     export const CustomLabel = 'urn:reactodia:customLabel';
+    /**
+     * Link state property to mark link as present only on the diagram but
+     * missing from the data returned by a data provider.
+     */
     export const LayoutOnly = 'urn:reactodia:layoutOnly';
+    /**
+     * Element state property for selected page index when element is a group
+     * of multiple items displayed with pagination.
+     */
     export const GroupPageIndex = 'urn:reactodia:groupPageIndex';
+    /**
+     * Element state property for selected page size when element is a group
+     * of multiple items displayed with pagination.
+     */
     export const GroupPageSize = 'urn:reactodia:groupPageSize';
 }
 
+/**
+ * @see TemplateProperties.PinnedProperties
+ */
 export interface PinnedProperties {
     readonly [propertyId: string]: boolean;
 }

--- a/src/data/sparql/responseHandler.ts
+++ b/src/data/sparql/responseHandler.ts
@@ -3,10 +3,11 @@ import { HashMap, HashSet } from '../../coreUtils/hashMap';
 
 import * as Rdf from '../rdf/rdfModel';
 import {
-    LinkTypeModel, ElementTypeModel, ElementTypeGraph, ElementModel, LinkModel, PropertyTypeModel, LinkCount,
-    ElementIri, ElementTypeIri, LinkTypeIri, PropertyTypeIri, LinkedElement,
+    LinkTypeModel, ElementTypeModel, ElementTypeGraph, ElementModel, LinkModel, PropertyTypeModel,
+    ElementIri, ElementTypeIri, LinkTypeIri, PropertyTypeIri,
     hashSubtypeEdge, equalSubtypeEdges, equalLinks, hashLink
 } from '../model';
+import type { DataProviderLinkCount, DataProviderLookupItem } from '../provider';
 import { LinkConfiguration, PropertyConfiguration } from './sparqlDataProviderSettings';
 import {
     SparqlResponse, ClassBinding, ElementBinding, LinkBinding, ElementImageBinding, LinkCountBinding,
@@ -396,7 +397,9 @@ export function getConnectedLinkTypes(
     return Array.from(linkTypes.values());
 }
 
-export function getLinkStatistics(response: SparqlResponse<LinkCountBinding>): LinkCount | undefined {
+export function getLinkStatistics(
+    response: SparqlResponse<LinkCountBinding>
+): DataProviderLinkCount | undefined {
     for (const binding of response.results.bindings) {
         if (isRdfIri(binding.link)) {
             return getLinkCount(binding);
@@ -410,7 +413,7 @@ export function getFilteredData(
     sourceTypes: ReadonlySet<ElementTypeIri> | undefined,
     linkByPredicateType: ReadonlyMap<string, readonly LinkConfiguration[]> | undefined,
     openWorldLinks: boolean
-): LinkedElement[] {
+): DataProviderLookupItem[] {
     const predicateToConfig = linkByPredicateType ?? EMPTY_MAP;
 
     const instances = new Map<ElementIri, MutableElementModel>();
@@ -447,7 +450,7 @@ export function getFilteredData(
         }
     }
 
-    const linkedElements: LinkedElement[] = [];
+    const linkedElements: DataProviderLookupItem[] = [];
     for (const model of instances.values()) {
         const targetTypes = resultTypes.get(model.id);
         const doesMatchesDomain = openWorldLinks || (
@@ -593,7 +596,7 @@ function parseCount(countLiteral: Rdf.Literal): number {
     return Number.isFinite(numericCount) ? numericCount : 0;
 }
 
-function getLinkCount(sLinkType: LinkCountBinding): LinkCount {
+function getLinkCount(sLinkType: LinkCountBinding): DataProviderLinkCount {
     return {
         id: sLinkType.link.value as LinkTypeIri,
         inCount: parseCount(sLinkType.inCount),

--- a/src/data/sparql/sparqlDataProviderSettings.ts
+++ b/src/data/sparql/sparqlDataProviderSettings.ts
@@ -1,5 +1,5 @@
 /**
- * Dataset-schema specific settings for SPARQL data provider.
+ * Dataset-schema specific settings for `SparqlDataProvider`.
  *
  * @category Data
  */

--- a/src/data/utils.ts
+++ b/src/data/utils.ts
@@ -28,7 +28,7 @@ export function hashFnv32a(str: string, seed = 0x811c9dc5): number {
 }
 
 /**
- * Extracts local name for URI the same way as it's done in RDF4J.
+ * Extracts local name for URI the same way as it's done in [RDF4J](https://github.com/eclipse-rdf4j/rdf4j).
  */
 export function getUriLocalName(uri: string): string | undefined {
     let index = uri.indexOf('#');

--- a/src/data/validationApi.ts
+++ b/src/data/validationApi.ts
@@ -25,11 +25,13 @@ export interface ValidationEvent {
 }
 
 /**
+ * Provides a strategy to validate changes to the data in the graph authoring mode.
+ *
  * @category Core
  */
 export interface ValidationApi {
     /**
-     * Validate element and its outbound links.
+     * Validate an element (graph node) and its outbound links (graph edges).
      */
     validate(e: ValidationEvent): Promise<Array<ElementError | LinkError>>;
 }

--- a/src/diagram/canvasApi.ts
+++ b/src/diagram/canvasApi.ts
@@ -10,26 +10,118 @@ import type { PaperTransform } from './paper';
 import type { ToDataURLOptions } from './toSvg';
 
 /**
+ * Describes an API to interact with a scrollable graph canvas.
+ *
  * @category Core
  */
 export interface CanvasApi {
+    /**
+     * Events for the scrollable graph canvas.
+     */
     readonly events: Events<CanvasEvents>;
+    /**
+     * Canvas-specific state for rendering graph content (elements, links, etc).
+     */
     readonly renderingState: RenderingState;
+    /**
+     * Live state for the current viewport size and transformation.
+     * 
+     * Allows to convert between different canvas coordinate types.
+     *
+     * This state can be captured to provide freezed state via `CanvasMetrics.snapshot()`.
+     */
     readonly metrics: CanvasMetrics;
+    /**
+     * Options for the scale-affecting operations on the canvas.
+     */
+    readonly zoomOptions: Required<ZoomOptions>;
+    /**
+     * Default action on moving pointer with pressed main button.
+     *
+     * Initial mode is `panning`.
+     */
+    readonly pointerMode: CanvasPointerMode;
+    /**
+     * Sets default action on moving pointer with pressed main button.
+     */
+    setPointerMode(value: CanvasPointerMode): void;
+    /**
+     * Changes the viewport such that its center is aligned to specified point
+     * in paper coordinates.
+     *
+     * If no point is specified, aligns the viewport center with the canvas center instead.
+     */
     centerTo(
         paperPosition?: Vector,
         options?: CenterToOptions
     ): Promise<void>;
+    /**
+     * Changes the viewport such that center of the bounding box for the graph content
+     * is aligned to the viewport center.
+     */
     centerContent(options?: ViewportOptions): Promise<void>;
+    /**
+     * Returns the current scale of the graph content in relation to the viewport.
+     */
     getScale(): number;
+    /**
+     * Changes the viewport to set specific scale of the graph content.
+     *
+     * If `pivot` is specified, the viewport is changed as if the canvas was
+     * zoomed-in or zoomed-out at that point of the canvas
+     * (e.g. by mouse wheel or pinch-zoom at the pivot).
+     */
     setScale(value: number, options?: ScaleOptions): Promise<void>;
+    /**
+     * Same as `setScale()` but relative to the current scale value.
+     *
+     * @see CanvasApi.setScale()
+     */
     zoomBy(value: number, options?: ScaleOptions): Promise<void>;
+    /**
+     * Same as `zoomBy()` with a positive zoom step value.
+     *
+     * @see CanvasApi.zoomBy()
+     */
     zoomIn(scaleOptions?: ScaleOptions): Promise<void>;
+    /**
+     * Same as `zoomBy()` with a negative zoom step value.
+     *
+     * @see CanvasApi.zoomBy()
+     */
     zoomOut(scaleOptions?: ScaleOptions): Promise<void>;
+    /**
+     * Changes the viewport to fit the whole graph content if possible.
+     *
+     * If the diagram is empty, centers the viewport at the middle of the canvas.
+     *
+     * @see CanvasApi.zoomToFitRect()
+     */
     zoomToFit(options?: ViewportOptions): Promise<void>;
+    /**
+     * Changes the viewport to fit specified rectangle area in paper coordinates if possible.
+     *
+     * @see CanvasApi.zoomToFit()
+     */
     zoomToFitRect(paperRect: Rect, options?: ViewportOptions): Promise<void>;
+    /**
+     * Exports the diagram as a serialized SVG document (XML text content).
+     *
+     * Exported SVG document would include all diagram content as well as every CSS rule
+     * which applies to any DOM element from the diagram content.
+     */
     exportSvg(options?: ExportSvgOptions): Promise<string>;
+    /**
+     * Exports the diagram as a rendered raster image (e.g. PNG, JPEG, etc)
+     * serialized into base64-encoded [data URL](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data).
+     */
     exportRaster(options?: ExportRasterOptions): Promise<string>;
+    /**
+     * Returns `true` if there is an active animation for graph or links on the canvas;
+     * otherwise `false`.
+     *
+     * @see CanvasApi.animateGraph()
+     */
     isAnimatingGraph(): boolean;
     /**
      * Starts animation for graph elements and links.
@@ -37,73 +129,256 @@ export interface CanvasApi {
      * @param setupChanges immediately called function to perform animatable changes on graph
      * @param duration animation duration in milliseconds (requires custom CSS to override)
      * @returns promise which resolves when this animation ends
+     *
+     * **Example**:
+     * ```js
+     * // Animate element movement by 200px (in paper coordinates) on the x-axis
+     * const target = model.getElement(...);
+     * canvas.animateGraph(() => {
+     *     const {x, y} = target.position;
+     *     target.setPosition(x + 200, y);
+     * });
+     * ```
      */
     animateGraph(setupChanges: () => void, duration?: number): Promise<void>;
 }
 
+/**
+ * Event data for `CanvasApi` events.
+ *
+ * @see CanvasApi
+ */
 export interface CanvasEvents {
+    /**
+     * Triggered on [pointer down](https://developer.mozilla.org/en-US/docs/Web/API/Element/pointerdown_event)
+     * event in the canvas.
+     */
     pointerDown: CanvasPointerEvent;
+    /**
+     * Triggered on [pointer move](https://developer.mozilla.org/en-US/docs/Web/API/Element/pointermove_event)
+     * event in the canvas.
+     */
     pointerMove: CanvasPointerEvent;
+    /**
+     * Triggered on [pointer up](https://developer.mozilla.org/en-US/docs/Web/API/Element/pointerup_event)
+     * event in the canvas.
+     */
     pointerUp: CanvasPointerUpEvent;
+    /**
+     * Triggered on [scroll](https://developer.mozilla.org/en-US/docs/Web/API/Element/scroll_event)
+     * event in the canvas.
+     */
     scroll: CanvasScrollEvent;
+    /**
+     * Triggered on [drop](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/drop_event)
+     * event from a drag and drop operation on the canvas.
+     */
     drop: CanvasDropEvent;
+    /**
+     * Triggered on [contextmenu](https://developer.mozilla.org/en-US/docs/Web/API/Element/contextmenu_event/)
+     * event (opening a context menu) in the canvas.
+     */
     contextMenu: CanvasContextMenuEvent;
+    /**
+     * Triggered on `isAnimatingGraph()` property change.
+     */
     changeAnimatingGraph: PropertyChange<CanvasApi, boolean>;
+    /**
+     * Triggered on `pointerMode` property change.
+     */
+    changePointerMode: PropertyChange<CanvasApi, CanvasPointerMode>;
+    /**
+     * Triggered on `getScale()` property change.
+     */
     changeScale: PropertyChange<CanvasApi, number>;
 }
 
+/**
+ * Event data for canvas pointer events.
+ */
 export interface CanvasPointerEvent {
+    /**
+     * Event source (canvas).
+     */
     readonly source: CanvasApi;
+    /**
+     * Original (raw) event data.
+     */
     readonly sourceEvent: React.MouseEvent<Element> | MouseEvent;
+    /**
+     * Pointer event target (element, link, link vertex).
+     *
+     * If `undefined` then the pointer event target is an empty canvas space.
+     */
     readonly target: Cell | undefined;
+    /**
+     * `true` if event triggered while viewport is being panned (moved);
+     * otherwise `false`.
+     */
     readonly panning: boolean;
 }
 
+/**
+ * Event data for canvas pointer up event.
+ */
 export interface CanvasPointerUpEvent extends CanvasPointerEvent {
+    /**
+     * `true` if the pointer up event should be considered as a "click"
+     * on the target because it immediately follows pointer down event
+     * without any pointer moves in-between.
+     */
     readonly triggerAsClick: boolean;
 }
 
+/**
+ * Event data for canvas scroll event.
+ */
 export interface CanvasScrollEvent {
+    /**
+     * Event source (canvas).
+     */
     readonly source: CanvasApi;
+    /**
+     * Original (raw) event data.
+     */
     readonly sourceEvent: Event;
 }
 
+/**
+ * Event data for canvas drop event from a drag and drop operation.
+ */
 export interface CanvasDropEvent {
+    /**
+     * Event source (canvas).
+     */
     readonly source: CanvasApi;
+    /**
+     * Original (raw) event data.
+     */
     readonly sourceEvent: DragEvent;
+    /**
+     * Position of the drop in paper coordinates.
+     */
     readonly position: Vector;
 }
 
+/**
+ * Event data for canvas context menu open request event.
+ */
 export interface CanvasContextMenuEvent {
+    /**
+     * Event source (canvas).
+     */
     readonly source: CanvasApi;
+    /**
+     * Original (raw) event data.
+     */
     readonly sourceEvent: React.MouseEvent;
+    /**
+     * Pointer event target (element, link, link vertex).
+     *
+     * If `undefined` then the pointer event target is an empty canvas space.
+     */
     readonly target: Cell | undefined;
 }
 
+/**
+ * Represents canvas viewport size and transformation.
+ *
+ * Allows to convert between different canvas coordinate types.
+ */
 export interface CanvasMetrics {
+    /**
+     * Sizes and offsets for the canvas area DOM element.
+     */
     readonly area: CanvasAreaMetrics;
+    /**
+     * Returns transformation data between paper and scrollable pane coordinates.
+     */
     getTransform(): PaperTransform;
+    /**
+     * Returns a immutable instance of this metrics which is guaranteed to
+     * never change even if original canvas viewport changes.
+     */
     snapshot(): CanvasMetrics;
+    /**
+     * Returns paper size in paper coordinates.
+     */
     getPaperSize(): { width: number; height: number };
-
+    /**
+     * Translates page to paper coordinates.
+     */
     pageToPaperCoords(pageX: number, pageY: number): Vector;
-    paperToPageCoords(paperX: number, paperY: number): Vector
+    /**
+     * Translates paper to page coordinates.
+     */
+    paperToPageCoords(paperX: number, paperY: number): Vector;
+    /**
+     * Translates client (viewport) to paper coordinates.
+     */
     clientToPaperCoords(areaClientX: number, areaClientY: number): Vector;
+    /**
+     * Translates client (viewport) to scrollable pane coordinates.
+     */
     clientToScrollablePaneCoords(areaClientX: number, areaClientY: number): Vector;
-    scrollablePaneToClientCoords(paneX: number, paneY: number): Vector
+    /**
+     * Translates scrollable pane to client (viewport) coordinates.
+     */
+    scrollablePaneToClientCoords(paneX: number, paneY: number): Vector;
+    /**
+     * Translates scrollable pane to paper coordinates.
+     */
     scrollablePaneToPaperCoords(paneX: number, paneY: number): Vector;
+    /**
+     * Translates paper to scrollable pane coordinates.
+     */
     paperToScrollablePaneCoords(paperX: number, paperY: number): Vector;
 }
 
+/**
+ * Contains sizes and offsets for the canvas area DOM element.
+ */
 export interface CanvasAreaMetrics {
+    /**
+     * Canvas area [client width](https://developer.mozilla.org/en-US/docs/Web/API/Element/clientWidth).
+     */
     readonly clientWidth: number;
+    /**
+     * Canvas area [client height](https://developer.mozilla.org/en-US/docs/Web/API/Element/clientHeight).
+     */
     readonly clientHeight: number;
+    /**
+     * Canvas area [offset width](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetWidth).
+     */
     readonly offsetWidth: number;
+    /**
+     * Canvas area [offset height](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetHeight).
+     */
     readonly offsetHeight: number;
+    /**
+     * Canvas area [scroll width](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollWidth).
+     */
     readonly scrollLeft: number;
+    /**
+     * Canvas area [scroll height](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight).
+     */
     readonly scrollTop: number;
 }
 
+/**
+ * Action on moving pointer with pressed main button:
+ *   - `panning` - pans the viewport over canvas;
+ *   - `selection` - starts selection of the cells on canvas.
+ *
+ * This mode may be changed to another while `Shift` button is being held
+ * (this should be implemented separately when the property value is used
+ * in other components).
+ */
+export type CanvasPointerMode = 'panning' | 'selection';
+
+/**
+ * Options for `CanvasApi` methods affecting the viewport.
+ */
 export interface ViewportOptions {
     /**
      * True if operation should be animated.
@@ -122,16 +397,78 @@ export interface ViewportOptions {
     duration?: number;
 }
 
+/**
+ * Options for `CanvasApi.centerTo()` method.
+ */
 export interface CenterToOptions extends ViewportOptions {
+    /**
+     * Scale to set when changing the viewport.
+     */
     scale?: number;
 }
 
+/**
+ * Options for `CanvasApi` methods affecting canvas scale.
+ */
 export interface ScaleOptions extends ViewportOptions {
+    /**
+     * Scale pivot position in paper coordinates.
+     */
     pivot?: Vector;
 }
 
 /**
+ * Options for the behavior of operation affecting scale on the canvas.
+ */
+export interface ZoomOptions {
+    /**
+     * Minimum scale factor.
+     *
+     * @default 0.2
+     */
+    min?: number;
+    /**
+     * Maximum scale factor.
+     *
+     * @default 2
+     */
+    max?: number;
+    /**
+     * Same as `max` but used only for zoom-to-fit to limit the scale factor
+     * on small diagrams.
+     *
+     * @default 1
+     */
+    maxFit?: number;
+    /**
+     * Scale step for the zoom-in and zoom-out operations.
+     *
+     * @default 0.1
+     */
+    step?: number;
+    /**
+     * Padding from each viewport border for zoom-to-fit scaling.
+     *
+     * @default 20
+     */
+    fitPadding?: number;
+    /**
+     * Whether `Ctrl`/`Cmd` keyboard key should be held to zoom
+     * with the mouse wheel.
+     *
+     * If `true`, the mouse wheel will be used to scroll viewport
+     * horizontally or vertically if `Shift` is held;
+     * otherwise the wheel action will be inverted.
+     *
+     * @default true
+     */
+    requireCtrl?: boolean;
+}
+
+/**
  * Options for exporting diagram as SVG image.
+ *
+ * @see CanvasApi.exportSvg()
  */
 export interface ExportSvgOptions {
     /**
@@ -157,18 +494,48 @@ export interface ExportSvgOptions {
 
 /**
  * Options for exporting diagram as raster image (e.g. JPEG, PNG, etc).
+ *
+ * @see CanvasApi.exportRaster()
  */
 export interface ExportRasterOptions extends ExportSvgOptions, ToDataURLOptions {}
 
+/**
+ * Canvas widget layer to render widget:
+ *   - `viewport` - topmost layer, uses client (viewport) coordinates and
+ *     does not scale or scroll with the diagram;
+ *   - `overElements` - displayed over both elements and links, uses paper coordinates,
+ *     scales and scrolls with the diagram;
+ *   - `overLinks` - displayed under elements but over links, uses paper coordinates,
+ *     scales and scrolls with the diagram.
+ */
 export type CanvasWidgetAttachment = 'viewport' | 'overElements' | 'overLinks';
 
+/**
+ * Describes canvas widget element to render on the specific widget layer.
+ */
 export interface CanvasWidgetDescription {
+    /**
+     * Canvas widget element to render.
+     */
     element: React.ReactElement;
+    /**
+     * Canvas widget layer to render widget on.
+     */
     attachment: CanvasWidgetAttachment;
 }
 
+/**
+ * Represents a context for everything rendered inside the canvas,
+ * including diagram content and widgets.
+ */
 export interface CanvasContext {
+    /**
+     * The canvas API.
+     */
     readonly canvas: CanvasApi;
+    /**
+     * Model for the diagram displayed by the canvas.
+     */
     readonly model: DiagramModel;
 }
 
@@ -176,6 +543,10 @@ export interface CanvasContext {
 export const CanvasContext = React.createContext<CanvasContext | null>(null);
 
 /**
+ * React hook to get current canvas context.
+ *
+ * Throws an error if called from component which is outside the canvas.
+ *
  * @category Hooks
  */
 export function useCanvas(): CanvasContext {

--- a/src/diagram/canvasWidget.tsx
+++ b/src/diagram/canvasWidget.tsx
@@ -9,6 +9,23 @@ interface WithMetadata {
 }
 
 /**
+ * Defines the React component to be a canvas widget. 
+ *
+ * A component cannot be rendered by canvas as widget unless explicitly
+ * defined as such using this function.
+ *
+ * **Example**:
+ * ```jsx
+ * function MyWidget(props) {
+ *    ...
+ * }
+ * 
+ * defineCanvasWidget(MyWidget, element => ({
+ *     element,
+ *     attachment: 'viewport'
+ * }));
+ * ```
+ *
  * @category Core
  */
 export function defineCanvasWidget<P>(

--- a/src/diagram/customization.ts
+++ b/src/diagram/customization.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type * as React from 'react';
 
 import type { LinkTypeIri, PropertyTypeIri } from '../data/model';
 import type * as Rdf from '../data/rdf/rdfModel';
@@ -7,74 +7,237 @@ import type { Element, ElementTemplateState, Link } from './elements';
 import type { SizeProvider, Vector } from './geometry';
 import type { GraphStructure } from './model';
 
+/**
+ * Selects a single preferred literal for the target language out of several candidates.
+ *
+ * Language code is specified as lowercase [BCP47](https://www.rfc-editor.org/rfc/rfc5646)
+ * string (examples: `en`, `en-gb`, etc).
+ *
+ * @param labels candidate literal with same or different language codes
+ * @param language target language code
+ * @returns selected literal or `undefined` if no suitable literal was found
+ */
 export type LabelLanguageSelector =
     (labels: ReadonlyArray<Rdf.Literal>, language: string) => Rdf.Literal | undefined;
 
+/**
+ * Property with resolved label to display in the UI.
+ */
 export interface FormattedProperty {
+    /**
+     * Property IRI.
+     */
     readonly propertyId: PropertyTypeIri;
+    /**
+     * Formatted property label.
+     */
     readonly label: string;
+    /**
+     * Property values.
+     */
     readonly values: ReadonlyArray<Rdf.NamedNode | Rdf.Literal>;
 }
 
+/**
+ * Provides a custom type style for an element with specific set of types.
+ *
+ * @param types sorted array of element type IRIs
+ * @returns custom type style for the specific combination of element types or
+ *     `undefined` if default style should be used
+ */
 export type TypeStyleResolver = (types: ReadonlyArray<string>) => TypeStyle | undefined;
+/**
+ * Provides a custom component to render element on a diagram.
+ */
 export type ElementTemplateResolver = (element: Element) => ElementTemplate | undefined;
+/**
+ * Provides a custom rendering on a diagram for links of specific type.
+ */
 export type LinkTemplateResolver = (linkTypeId: LinkTypeIri) => LinkTemplate | undefined;
 
+/**
+ * Common style for a type or set of types to display in various parts of the UI.
+ */
 export interface TypeStyle {
+    /**
+     * CSS color string.
+     */
     readonly color?: string;
+    /**
+     * Icon image URL.
+     */
     readonly icon?: string;
 }
 
+/**
+ * Custom component to render a single diagram element.
+ */
 export type ElementTemplate = React.ComponentType<TemplateProps>;
 
+/**
+ * Props for a custom `ElementTemplate` component.
+ *
+ * @see ElementTemplate
+ */
 export interface TemplateProps {
+    /**
+     * Target element ID (`Element.id`).
+     */
     readonly elementId: string;
+    /**
+     * Target element to render.
+     */
     readonly element: Element;
+    /**
+     * Specifies whether element is in the expanded state.
+     *
+     * Same as `element.isExpanded`.
+     */
     readonly isExpanded: boolean;
+    /**
+     * Template-specific state for the element.
+     *
+     * Same as `element.elementState`.
+     */
     readonly elementState?: ElementTemplateState;
 }
 
+/**
+ * Custom template to render links with the same link type. 
+ */
 export interface LinkTemplate {
+    /**
+     * SVG path marker style at the source of the link.
+     */
     markerSource?: LinkMarkerStyle;
+    /**
+     * SVG path marker style at the target of the link.
+     */
     markerTarget?: LinkMarkerStyle;
+    /**
+     * Renders the link component on SVG canvas.
+     */
     renderLink(props: LinkTemplateProps): React.ReactNode;
-    editableLabel?: EditableLinkLabel;
-}
-
-export interface EditableLinkLabel {
-    getLabel(link: Link): string | undefined;
-    setLabel(link: Link, label: string): void;
-}
-
-export interface LinkMarkerStyle {
-    readonly d?: string;
-    readonly width?: number;
-    readonly height?: number;
-    readonly fill?: string;
-    readonly stroke?: string;
-    readonly strokeWidth?: string;
-}
-
-export interface LinkTemplateProps {
-    link: Link;
-    typeIndex: number;
-    path: string;
-    getPathPosition: (offset: number) => Vector;
-    route?: RoutedLink;
-    editableLabel?: EditableLinkLabel;
 }
 
 /**
+ * Custom style for SVG path markers at link ends.
+ *
+ * @see LinkTemplate
+ */
+export interface LinkMarkerStyle {
+    /**
+     * SVG path geometry for the marker.
+     */
+    readonly d?: string;
+    /**
+     * SVG marker width (px).
+     */
+    readonly width?: number;
+    /**
+     * SVG marker height (px).
+     */
+    readonly height?: number;
+    /**
+     * SVG marker fill (background) color.
+     */
+    readonly fill?: string;
+    /**
+     * SVG marker stroke (line) color.
+     */
+    readonly stroke?: string;
+    /**
+     * SVG marker stroke (line) thickness.
+     */
+    readonly strokeWidth?: string | number;
+}
+
+/**
+ * Props for custom link template rendering.
+ *
+ * @see LinkTemplate.renderLink()
+ */
+export interface LinkTemplateProps {
+    /**
+     * Target link to render.
+     */
+    link: Link;
+    /**
+     * SVG path for the link geometry.
+     */
+    path: string;
+    /**
+     * Provides paper position along the link at the specified offset.
+     *
+     * Offset of `0.0` corresponds to the source
+     * and `1.0` corresponds to the target of the link.
+     */
+    getPathPosition: (offset: number) => Vector;
+    /**
+     * SVG path marker for the link source.
+     */
+    markerSource: string;
+    /**
+     * SVG path marker for the link target.
+     */
+    markerTarget: string;
+    /**
+     * Route data (geometry) for the link.
+     */
+    route?: RoutedLink;
+}
+
+/**
+ * Provides custom geometry for links based on connections between elements
+ * and their positions and sizes.
+ *
  * @category Core
  */
 export interface LinkRouter {
-    route(model: GraphStructure, sizeProvider: SizeProvider): RoutedLinks;
+    /**
+     * Computes route data for each link of the specified `graph`.
+     */
+    route(graph: GraphStructure, sizeProvider: SizeProvider): RoutedLinks;
 }
 
+/**
+ * Maps `Link.id` to the route data for that link.
+ */
 export type RoutedLinks = Map<string, RoutedLink>;
 
+/**
+ * Route data (geometry) for a link.
+ */
 export interface RoutedLink {
+    /**
+     * Target link ID (`Link.id`).
+     */
     readonly linkId: string;
+    /**
+     * Override for the link vertices (`Link.vertices`).
+     */
     readonly vertices: ReadonlyArray<Vector>;
+    /**
+     * Override for default text alignment for all link labels.
+     */
     readonly labelTextAnchor?: 'start' | 'middle' | 'end';
+}
+
+/**
+ * Provides a strategy to rename diagram links (change labels).
+ */
+export interface RenameLinkHandler {
+    /**
+     * Returns `true` if the target link has editable label.
+     */
+    canRename(link: Link): boolean;
+    /**
+     * Gets changed label for the link if renamed,
+     * otherwise `undefined`.
+     */
+    getLabel(link: Link): string | undefined;
+    /**
+     * Sets changed label for the link.
+     */
+    setLabel(link: Link, label: string): void;
 }

--- a/src/diagram/elementLayer.tsx
+++ b/src/diagram/elementLayer.tsx
@@ -9,12 +9,12 @@ import { TemplateProps } from './customization';
 import { setElementExpanded } from './commands';
 import { Element, VoidElement } from './elements';
 import { DiagramModel } from './model';
-import { RenderingState, RenderingLayer } from './renderingState';
+import { MutableRenderingState, RenderingLayer } from './renderingState';
 import { SharedCanvasState, IriClickIntent } from './sharedCanvasState';
 
 export interface ElementLayerProps {
     model: DiagramModel;
-    renderingState: RenderingState;
+    renderingState: MutableRenderingState;
     style: React.CSSProperties;
 }
 
@@ -270,7 +270,7 @@ function computeTemplateProps(element: Element): TemplateProps {
 interface OverlaidElementProps {
     state: ElementState;
     model: DiagramModel;
-    renderingState: RenderingState;
+    renderingState: MutableRenderingState;
     onResize: (model: Element, node: HTMLDivElement) => void;
 }
 

--- a/src/diagram/graph.ts
+++ b/src/diagram/graph.ts
@@ -14,9 +14,23 @@ export interface GraphEvents {
     changeLinkVisibility: PropertyChange<LinkTypeIri, LinkTypeVisibility>;
 }
 
+/**
+ * Event data for diagram cells changed event.
+ */
 export interface CellsChangedEvent {
+    /**
+     * If `true`, it should be assumed that many elements or links
+     * were added or removed at the same time, and any caches based
+     * on the diagram content should be completely re-computed.
+     */
     readonly updateAll: boolean;
+    /**
+     * Specific element was added or removed.
+     */
     readonly changedElement?: Element;
+    /**
+     * Specific links were added or removed.
+     */
     readonly changedLinks?: ReadonlyArray<Link>;
 }
 

--- a/src/diagram/layoutShared.ts
+++ b/src/diagram/layoutShared.ts
@@ -249,6 +249,15 @@ export interface DefaultLayoutOptions {
 }
 
 /**
+ * Default (fallback) diagram layout function.
+ *
+ * The algorithm used is force-directed layout from [cola.js](https://ialab.it.monash.edu/webcola/).
+ *
+ * This function is computationally expensive and should be used only as fallback
+ * when other ways to compute diagram layout is not available.
+ * The recommended way is to use web workers via `@reactodia/workspace/layout.worker`
+ * and `Reactodia.useWorker()`.
+ *
  * @category Geometry
  */
 export function blockingDefaultLayout(

--- a/src/diagram/linkRouter.ts
+++ b/src/diagram/linkRouter.ts
@@ -5,10 +5,30 @@ import type { Link } from './elements';
 import { SizeProvider, Vector, Rect, boundsOf } from './geometry';
 
 /**
+ * Options for `DefaultLinkRouter`.
+ */
+export interface DefaultLinkRouterOptions {
+    /**
+     * Margin to put between the middle parts of links to move
+     * them apart of each other.
+     *
+     * @default 20
+     */
+    gap?: number;
+}
+
+/**
+ * Default link router which moves links with same source and target apart.
+ *
  * @category Core
  */
 export class DefaultLinkRouter implements LinkRouter {
-    constructor(private gap = 20) {}
+    private readonly gap: number;
+
+    constructor(options: DefaultLinkRouterOptions = {}) {
+        const {gap = 20} = options;
+        this.gap = gap;
+    }
 
     route(model: GraphStructure, sizeProvider: SizeProvider): RoutedLinks {
         const routings: RoutedLinks = new Map();

--- a/src/diagram/paper.tsx
+++ b/src/diagram/paper.tsx
@@ -6,11 +6,11 @@ import { ElementLayer } from './elementLayer';
 import { Vector } from './geometry';
 import { LinkLayer, LinkMarkers } from './linkLayer';
 import { DiagramModel } from './model';
-import { RenderingState } from './renderingState';
+import { MutableRenderingState } from './renderingState';
 
 export interface PaperProps {
     model: DiagramModel;
-    renderingState: RenderingState;
+    renderingState: MutableRenderingState;
     paperTransform: PaperTransform;
     svgCanvasRef?: React.RefObject<SVGSVGElement>;
     onPointerDown?: (e: React.PointerEvent<HTMLElement>, cell: Cell | undefined) => void;
@@ -129,6 +129,8 @@ function findCell(bottom: Element, top: Element, model: DiagramModel): Cell | un
 }
 
 /**
+ * Transformation data between paper and scrollable pane coordinates.
+ *
  * @category Geometry
  */
 export interface PaperTransform {
@@ -141,6 +143,11 @@ export interface PaperTransform {
     paddingY: number;
 }
 
+/**
+ * Props for `TransformedSvgCanvas` component.
+ *
+ * @see TransformedSvgCanvas
+ */
 export interface TransformedSvgCanvasProps extends React.HTMLProps<SVGSVGElement> {
     paperTransform: PaperTransform;
     svgCanvasRef?: React.RefObject<SVGSVGElement>;
@@ -153,6 +160,8 @@ const TRANSFORMED_SVG_CANVAS_STYLE: Readonly<CSSProperties> = {
 };
 
 /**
+ * SVG canvas component to render its children on the diagram in paper coordinate system.
+ *
  * @category Components
  */
 export function TransformedSvgCanvas(props: TransformedSvgCanvasProps) {
@@ -199,6 +208,8 @@ export function paneTopLeft(pt: PaperTransform): Vector {
 }
 
 /**
+ * Translates paper to scrollable pane coordinates.
+ *
  * @category Geometry
  */
 export function paneFromPaperCoords(paper: Vector, pt: PaperTransform): Vector {
@@ -209,6 +220,8 @@ export function paneFromPaperCoords(paper: Vector, pt: PaperTransform): Vector {
 }
 
 /**
+ * Translates scrollable pane to paper coordinates.
+ *
  * @category Geometry
  */
 export function paperFromPaneCoords(pane: Vector, pt: PaperTransform): Vector {

--- a/src/diagram/sharedCanvasState.ts
+++ b/src/diagram/sharedCanvasState.ts
@@ -2,32 +2,69 @@ import * as React from 'react';
 
 import { Events, EventSource, EventObserver, PropertyChange } from '../coreUtils/events';
 
+import { TemplateProperties } from '../data/schema';
+
 import type {
-    CanvasApi, CanvasDropEvent, CanvasWidgetDescription, CanvasWidgetAttachment,
+    CanvasApi, CanvasDropEvent, CanvasWidgetDescription,
 } from './canvasApi';
-import type { ElementTemplate, LinkTemplate } from './customization';
+import type { ElementTemplate, LinkTemplate, RenameLinkHandler } from './customization';
 import { Element, Link } from './elements';
 import type { LayoutFunction } from './layout';
 
+/**
+ * Event data for `SharedCanvasState` events.
+ *
+ * @see SharedCanvasState
+ */
 export interface SharedCanvasStateEvents {
+    /**
+     * Triggered on `highlighter` property change.
+     */
     changeHighlight: PropertyChange<
         SharedCanvasState,
         CellHighlighter | undefined
     >;
+    /**
+     * Triggered on `widgets` property change.
+     */
     changeWidgets: PropertyChange<
         SharedCanvasState,
         ReadonlyMap<string, CanvasWidgetDescription>
     >;
+    /**
+     * Triggered on a request to find all canvases using this state.
+     */
     findCanvas: FindCanvasEvent;
+    /**
+     * Triggered on request to navigate to a specific IRI.
+     *
+     * @deprecated Use element templates to change how IRIs should be opened.
+     */
     iriClick: IriClickEvent;
-    dispose: { readonly source: SharedCanvasState };
+    /**
+     * Triggered when all rendering-related state should be disposed.
+     */
+    dispose: {
+        /**
+         * Event source (shared canvas state).
+         */
+        readonly source: SharedCanvasState;
+    };
 }
 
+/**
+ * Event data for a request to find all canvases using this state.
+ */
 export interface FindCanvasEvent {
-    canvases: CanvasApi[];
+    /**
+     * Collects found canvas instances.
+     */
+    readonly canvases: CanvasApi[];
 }
 
+/** @deprecated */
 export type IriClickIntent = 'jumpToEntity' | 'openEntityIri' | 'openOtherIri';
+/** @deprecated */
 export interface IriClickEvent {
     iri: string;
     element: Element;
@@ -35,22 +72,33 @@ export interface IriClickEvent {
     originalEvent: React.MouseEvent<any>;
 }
 
+/**
+ * For a each diagram cell tells whether it should be highlighted or blurred.
+ */
 export type CellHighlighter = (item: Element | Link) => boolean;
 
+/** @hidden */
 export type ElementDecoratorResolver = (element: Element) => React.ReactNode | undefined;
 
+/** @hidden */
 export interface SharedCanvasStateOptions {
     defaultElementTemplate: ElementTemplate;
     defaultLinkTemplate: LinkTemplate;
     defaultLayout: LayoutFunction;
+    renameLinkHandler?: RenameLinkHandler;
 }
 
 /**
+ * Stores common state and settings for multiple canvases.
+ *
  * @category Core
  */
 export class SharedCanvasState {
     private readonly listener = new EventObserver();
     private readonly source = new EventSource<SharedCanvasStateEvents>();
+    /**
+     * Event for the shared canvas state.
+     */
     readonly events: Events<SharedCanvasStateEvents> = this.source;
 
     private disposed = false;
@@ -60,52 +108,91 @@ export class SharedCanvasState {
     private _highlighter: CellHighlighter | undefined;
     private _elementDecorator: ElementDecoratorResolver | undefined;
 
+    /**
+     * Default element template to use as a fallback.
+     */
     readonly defaultElementTemplate: ElementTemplate;
+    /**
+     * Default link template to use as a fallback.
+     */
     readonly defaultLinkTemplate: LinkTemplate;
+    /**
+     * Default layout algorithm function to use if it's not specified explicitly.
+     */
     readonly defaultLayout: LayoutFunction;
+    /**
+     * A strategy to rename diagram links (change labels).
+     */
+    readonly renameLinkHandler: RenameLinkHandler | undefined;
 
     /** @hidden */
     constructor(options: SharedCanvasStateOptions) {
-        const {defaultElementTemplate, defaultLinkTemplate, defaultLayout} = options;
+        const {
+            defaultElementTemplate, defaultLinkTemplate, defaultLayout, renameLinkHandler,
+        } = options;
         this._canvasWidgets = new Map();
         this.defaultElementTemplate = defaultElementTemplate;
         this.defaultLinkTemplate = defaultLinkTemplate;
         this.defaultLayout = defaultLayout;
+        this.renameLinkHandler = renameLinkHandler;
     }
 
     /** @hidden */
-    dispose() {
+    dispose(): void {
         if (this.disposed) { return; }
         this.source.trigger('dispose', {source: this});
         this.listener.stopListening();
         this.disposed = true;
     }
 
+    /**
+     * Returns all canvases that use this shared state.
+     */
     findAllCanvases(): CanvasApi[] {
         const event: FindCanvasEvent = {canvases: []};
         this.source.trigger('findCanvas', event);
         return event.canvases;
     }
 
+    /**
+     * Returns any canvas that uses this shared state or `undefined` if none found.
+     */
     findAnyCanvas(): CanvasApi | undefined {
         const canvases = this.findAllCanvases();
         return canvases.length > 0 ? canvases[0] : undefined;
     }
 
-    onIriClick(iri: string, element: Element, clickIntent: IriClickIntent, event: React.MouseEvent<any>) {
+    /**
+     * Requests to navigate to a specific IRI.
+     *
+     * @deprecated
+     */
+    onIriClick(
+        iri: string,
+        element: Element,
+        clickIntent: IriClickIntent,
+        event: React.MouseEvent<any>
+    ): void {
         event.persist();
         event.preventDefault();
         this.source.trigger('iriClick', {iri, element, clickIntent, originalEvent: event});
     }
 
+    /**
+     * Live collection of canvas widgets rendered on each canvas.
+     */
     get widgets(): ReadonlyMap<string, CanvasWidgetDescription> {
         return this._canvasWidgets;
     }
 
-    setCanvasWidget(key: string, widget: {
-        element: React.ReactElement;
-        attachment: CanvasWidgetAttachment;
-    } | null) {
+    /**
+     * Adds, changes or removes a canvas widget from being rendered on the canvases.
+     *
+     * @param key unique key for a widget
+     * @param widget widget description with a target widget layer to render on
+     *        or `null` to remove the widget
+     */
+    setCanvasWidget(key: string, widget: CanvasWidgetDescription | null): void {
         const previous = this._canvasWidgets;
         const nextWidgets = new Map(previous);
         if (widget) {
@@ -121,10 +208,23 @@ export class SharedCanvasState {
         this.source.trigger('changeWidgets', {source: this, previous});
     }
 
-    setHandlerForNextDropOnPaper(handler: ((e: CanvasDropEvent) => void) | undefined) {
+    /**
+     * Sets the handler for the next drop event from drag-and-drop operation on a canvas.
+     *
+     * **Experimental**: this feature will likely change in the future.
+     */
+    setHandlerForNextDropOnPaper(handler: ((e: CanvasDropEvent) => void) | undefined): void {
         this.dropOnPaperHandler = handler;
     }
 
+    /**
+     * Tries to run previously set drop handler on a canvas,
+     * then removes the handler if it was set.
+     *
+     * **Experimental**: this feature will likely change in the future.
+     *
+     * @returns `true` if a handler was set, otherwise `false`
+     */
     tryHandleDropOnPaper(e: CanvasDropEvent): boolean {
         const {dropOnPaperHandler} = this;
         if (dropOnPaperHandler) {
@@ -136,8 +236,18 @@ export class SharedCanvasState {
         return false;
     }
 
+    /**
+     * Returns active highlight for the diagram cells.
+     *
+     * **Experimental**: this feature will likely change in the future.
+     */
     get highlighter(): CellHighlighter | undefined { return this._highlighter; }
-    setHighlighter(value: CellHighlighter | undefined) {
+    /**
+     * Sets or removes an active highlight for the diagram cells.
+     *
+     * **Experimental**: this feature will likely change in the future.
+     */
+    setHighlighter(value: CellHighlighter | undefined): void {
         const previous = this._highlighter;
         if (previous === value) { return; }
         this._highlighter = value;
@@ -145,12 +255,39 @@ export class SharedCanvasState {
     }
 
     /** @hidden */
-    _setElementDecorator(decorator: ElementDecoratorResolver | undefined) {
+    _setElementDecorator(decorator: ElementDecoratorResolver | undefined): void {
         this._elementDecorator = decorator;
     }
 
     /** @hidden */
     _decorateElement(element: Element): React.ReactNode | undefined {
         return this._elementDecorator?.(element);
+    }
+}
+
+export class RenameLinkToLinkStateHandler implements RenameLinkHandler {
+    canRename(link: Link): boolean {
+        return true;
+    }
+
+    getLabel(link: Link): string | undefined {
+        const {linkState} = link;
+        if (
+            linkState &&
+            Object.prototype.hasOwnProperty.call(linkState, TemplateProperties.CustomLabel)
+        ) {
+            const customLabel = linkState[TemplateProperties.CustomLabel];
+            if (typeof customLabel === 'string') {
+                return customLabel;
+            }
+        }
+        return undefined;
+    }
+
+    setLabel(link: Link, label: string): void {
+        link.setLinkState({
+            ...link.linkState,
+            [TemplateProperties.CustomLabel]: label.length === 0 ? undefined : label,
+        });
     }
 }

--- a/src/diagram/spinner.tsx
+++ b/src/diagram/spinner.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
 
+/**
+ * Props for `Spinner` component.
+ */
 export interface SpinnerProps {
     size?: number;
     position?: { x: number; y: number };
@@ -11,6 +14,8 @@ export interface SpinnerProps {
 const CLASS_NAME = 'reactodia-spinner';
 
 /**
+ * Utility SVG component that displays loading spinner.
+ *
  * @category Components
  */
 export function Spinner(props: SpinnerProps) {
@@ -34,7 +39,10 @@ export function Spinner(props: SpinnerProps) {
 }
 
 /**
+ * Same as `Spinner` component but for non-SVG context.
+ *
  * @category Components
+ * @see Spinner
  */
 export function HtmlSpinner(props: { width: number; height: number }) {
     const {width, height} = props;

--- a/src/diagram/toSvg.ts
+++ b/src/diagram/toSvg.ts
@@ -282,15 +282,57 @@ function foreachNode<T extends Node>(nodeList: NodeListOf<T>, callback: (node: T
     }
 }
 
+/**
+ * Options for exporting the canvas as raster image Base64-encoded into data URL.
+ */
 export interface ToDataURLOptions {
-    /** 'image/png' | 'image/jpeg' | ... */
+    /**
+     * [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types)
+     * for the exported raster image.
+     *
+     * Example: `image/png`, `image/jpeg`, ...
+     *
+     * @default "image/png"
+     */
     mimeType?: string;
+    /**
+     * Target width of the exported image.
+     *
+     * If only `width` is specified, the height is set based on the diagram aspect ratio,
+     * otherwise the diagram is fit into desired bounds with margins on sides.
+     *
+     * If neither `width` or `height` is set, the image size is computed automatically
+     * based on `maxFallbackSize` with 2x maximum resolution for the content.
+     */
     width?: number;
+    /**
+     * Target height of the exported image.
+     *
+     * If only `height` is specified, the height is set based on the diagram aspect ratio,
+     * otherwise the diagram is fit into desired bounds with margins on sides.
+     *
+     * If neither `width` or `height` is set, the image size is computed automatically
+     * based on `maxFallbackSize` with 2x maximum resolution for the content.
+     */
     height?: number;
-    /** Background color, transparent by default. */
+    /**
+     * Background color for the exported image.
+     *
+     * If not specified, the background is transparent by default.
+     */
     backgroundColor?: string;
+    /**
+     * Exported image quality value from 0.0 to 1.0
+     * (applicable only for lossy image types).
+     *
+     * @default 1.0
+     */
     quality?: number;
-    /** @default {width: 4096, height: 4096} */
+    /**
+     * Maximum exported image size when neither `width` nor `height` is specified.
+     *
+     * @default {width: 4096, height: 4096}
+     */
     maxFallbackSize?: Size;
 }
 

--- a/src/editor/authoredEntity.tsx
+++ b/src/editor/authoredEntity.tsx
@@ -11,11 +11,30 @@ import { EntityElement } from '../editor/dataElements';
 
 import { useWorkspace } from '../workspace/workspaceContext';
 
+/**
+ * Graph authoring status for an entity.
+ */
 export interface AuthoredEntityContext {
+    /**
+     * The new IRI if entity IRI has changed in the entity data,
+     * otherwise `undefined`.
+     */
     editedIri?: string;
+    /**
+     * Whether its allowed to change the entity data.
+     */
     canEdit: boolean | undefined;
+    /**
+     * Whether its allowed to delete the entity.
+     */
     canDelete: boolean | undefined;
+    /**
+     * Handler to begin editing the entity data from the UI.
+     */
     onEdit: (target: Element) => void;
+    /**
+     * Handler to delete the entity.
+     */
     onDelete: () => void;
 }
 
@@ -27,6 +46,8 @@ enum AllowedActions {
 }
 
 /**
+ * React hook to load entity authoring status for the graph authoring.
+ *
  * @category Hooks
  */
 export function useAuthoredEntity(

--- a/src/editor/dataElements.ts
+++ b/src/editor/dataElements.ts
@@ -16,15 +16,30 @@ import {
 import { Command } from '../diagram/history';
 import { DiagramModel } from '../diagram/model';
 
+/**
+ * Event data for `EntityElement` events.
+ *
+ * @see EntityElement
+ */
 export interface EntityElementEvents extends ElementEvents {
-    changeData: PropertyChange<Element, ElementModel>;
+    /**
+     * Triggered on `data` property change.
+     */
+    changeData: PropertyChange<EntityElement, ElementModel>;
 }
 
+/**
+ * Properties for `EntityElement`.
+ *
+ * @see EntityElement
+ */
 export interface EntityElementProps extends ElementProps {
     data: ElementModel;
 }
 
 /**
+ * Diagram element representing an graph entity referenced by an IRI.
+ *
  * @category Core
  */
 export class EntityElement extends Element {
@@ -37,6 +52,12 @@ export class EntityElement extends Element {
         this._data = props.data;
     }
 
+    /**
+     * Creates an empty (placeholder) data for the specified entity IRI.
+     *
+     * This data can be used to display an entity in the UI
+     * until the actual data is loaded from a data provider.
+     */
     static placeholderData(iri: ElementIri): ElementModel {
         return {
             id: iri,
@@ -63,6 +84,8 @@ export class EntityElement extends Element {
 }
 
 /**
+ * Command to set entity element data.
+ *
  * @category Commands
  */
 export function setEntityElementData(
@@ -76,15 +99,30 @@ export function setEntityElementData(
     });
 }
 
+/**
+ * Event data for `EntityGroup` events.
+ * 
+ * @see EntityGroup
+ */
 export interface EntityGroupEvents extends ElementEvents {
+    /**
+     * Triggered on `items` property change.
+     */
     changeItems: PropertyChange<EntityGroup, ReadonlyArray<EntityGroupItem>>;
 }
 
+/**
+ * Properties for `EntityGroup`.
+ *
+ * @see EntityGroup
+ */
 export interface EntityGroupProps extends ElementProps {
     items?: ReadonlyArray<EntityGroupItem>;
 }
 
 /**
+ * Diagram element representing a group of multiple graph entities.
+ *
  * @category Core
  */
 export class EntityGroup extends Element {
@@ -128,12 +166,19 @@ export class EntityGroup extends Element {
     }
 }
 
+/**
+ * Represents a single entity contained in the entity group.
+ *
+ * @see EntityGroup.items
+ */
 export interface EntityGroupItem {
     readonly data: ElementModel;
     readonly elementState?: ElementTemplateState | undefined;
 }
 
 /**
+ * Command to set entity group items.
+ *
  * @category Commands
  */
 export function setEntityGroupItems(group: EntityGroup, items: ReadonlyArray<EntityGroupItem>): Command {
@@ -145,6 +190,8 @@ export function setEntityGroupItems(group: EntityGroup, items: ReadonlyArray<Ent
 }
 
 /**
+ * Iterates over data for all entities of the target element.
+ *
  * @category Core
  */
 export function* iterateEntitiesOf(element: Element): Iterable<ElementModel> {
@@ -157,15 +204,31 @@ export function* iterateEntitiesOf(element: Element): Iterable<ElementModel> {
     }
 }
 
+/**
+ * Event data for `RelationLink` events.
+ *
+ * @see RelationLink
+ */
 export interface RelationLinkEvents extends LinkEvents {
-    changeData: PropertyChange<Link, LinkModel>;
+    /**
+     * Triggered on `data` property change.
+     */
+    changeData: PropertyChange<RelationLink, LinkModel>;
 }
 
+/**
+ * Properties for `RelationLink`.
+ *
+ * @see RelationLink
+ */
 export interface RelationLinkProps extends LinkProps {
     data: LinkModel;
 }
 
 /**
+ * Diagram link representing a graph relation, uniquely identified by
+ * (source entity IRI, target entity IRI, link type IRI) tuple.
+ *
  * @category Core
  */
 export class RelationLink extends Link {
@@ -192,7 +255,7 @@ export class RelationLink extends Link {
         if (previous === value) { return; }
         this._data = value;
         this.relationSource.trigger('changeData', {source: this, previous});
-        this.relationSource.trigger('requestedRedraw', {source: this, level: 'template'});
+        this.relationSource.trigger('requestedRedraw', {source: this});
     }
 
     withDirection(data: LinkModel): RelationLink {
@@ -211,6 +274,8 @@ export class RelationLink extends Link {
 }
 
 /**
+ * Command to set relation relation link data.
+ *
  * @category Commands
  */
 export function setRelationLinkData(
@@ -224,16 +289,31 @@ export function setRelationLinkData(
     });
 }
 
+/**
+ * Event data for `RelationGroup` events.
+ *
+ * @see RelationGroup
+ */
 export interface RelationGroupEvents extends LinkEvents {
+    /**
+     * Triggered on `items` property change.
+     */
     changeItems: PropertyChange<RelationGroup, ReadonlyArray<RelationGroupItem>>;
 }
 
+/**
+ * Properties for `RelationGroup`.
+ *
+ * @see RelationGroup
+ */
 export interface RelationGroupProps extends LinkProps {
     typeId: LinkTypeIri;
     items: ReadonlyArray<RelationGroupItem>;
 }
 
 /**
+ * Diagram link representing a group of multiple graph relations.
+ *
  * @category Core
  */
 export class RelationGroup extends Link {
@@ -276,7 +356,7 @@ export class RelationGroup extends Link {
         this._items = value;
         this.updateItemKeys();
         this.relationSource.trigger('changeItems', {source: this, previous});
-        this.relationSource.trigger('requestedRedraw', {source: this, level: 'template'});
+        this.relationSource.trigger('requestedRedraw', {source: this});
     }
 
     get itemKeys(): ReadonlyHashSet<LinkKey> {
@@ -303,12 +383,19 @@ export class RelationGroup extends Link {
     }
 }
 
+/**
+ * Represents a single relation contained in the relation group.
+ *
+ * @see RelationGroup.items
+ */
 export interface RelationGroupItem {
     readonly data: LinkModel;
     readonly linkState?: LinkTemplateState | undefined;
 }
 
 /**
+ * Command to set relation group items.
+ *
  * @category Commands
  */
 export function setRelationGroupItems(group: RelationGroup, items: ReadonlyArray<RelationGroupItem>): Command {
@@ -320,6 +407,8 @@ export function setRelationGroupItems(group: RelationGroup, items: ReadonlyArray
 }
 
 /**
+ * Iterates over data for all relations of the target link.
+ *
  * @category Core
  */
 export function* iterateRelationsOf(link: Link): Iterable<LinkModel> {
@@ -332,11 +421,21 @@ export function* iterateRelationsOf(link: Link): Iterable<LinkModel> {
     }
 }
 
+/**
+ * Event data for `ElementType` events.
+ *
+ * @see ElementType
+ */
 export interface ElementTypeEvents {
+    /**
+     * Triggered on `data` property change.
+     */
     changeData: PropertyChange<ElementType, ElementTypeModel | undefined>;
 }
 
 /**
+ * Stores data of an entity type in the graph.
+ *
  * @category Core
  */
 export class ElementType {
@@ -371,11 +470,21 @@ export class ElementType {
     }
 }
 
+/**
+ * Event data for `PropertyType` events.
+ *
+ * @see PropertyType
+ */
 export interface PropertyTypeEvents {
+    /**
+     * Triggered on `data` property change.
+     */
     changeData: PropertyChange<PropertyType, PropertyTypeModel | undefined>;
 }
 
 /**
+ * Stores data of a property type in the graph.
+ *
  * @category Core
  */
 export class PropertyType {
@@ -410,11 +519,21 @@ export class PropertyType {
     }
 }
 
+/**
+ * Event data for `LinkType` events.
+ *
+ * @see LinkType
+ */
 export interface LinkTypeEvents {
+    /**
+     * Triggered on `data` property change.
+     */
     changeData: PropertyChange<LinkType, LinkTypeModel | undefined>;
 }
 
 /**
+ * Stores data of a link type in the graph.
+ *
  * @category Core
  */
 export class LinkType {
@@ -450,6 +569,12 @@ export class LinkType {
 }
 
 /**
+ * Command to replace data for all entities with target IRI on the diagram.
+ *
+ * If IRI in the new `data` is different from the `target`, the relations
+ * connected to the entities will have their data changed as well to refer
+ * to the same entities by the new IRI.
+ *
  * @category Commands
  */
 export function changeEntityData(model: DiagramModel, target: ElementIri, data: ElementModel): Command {
@@ -529,6 +654,11 @@ function mapRelationEndpoint(relation: LinkModel, oldIri: ElementIri, newIri: El
 }
 
 /**
+ * Command to replace data for all relations with same target identity.
+ *
+ * The relation identity should be the same for both `oldData` and `newData`
+ * otherwise an error wil be thrown.
+ *
  * @category Commands
  */
 export function changeRelationData(model: DiagramModel, oldData: LinkModel, newData: LinkModel): Command {

--- a/src/editor/dataFetcher.ts
+++ b/src/editor/dataFetcher.ts
@@ -18,16 +18,41 @@ export interface DataFetcherEvents {
     changeOperations: ChangeOperationsEvent;
 }
 
+/**
+ * Event data for change current fetch operations event.
+ */
 export interface ChangeOperationsEvent {
+    /**
+     * Previous operations before the change.
+     */
     readonly previous: ReadonlyArray<FetchOperation>;
+    /**
+     * If set, specifies the operation that failed and the fail reason (error).
+     */
     readonly fail?: FetchOperationFail;
 }
 
+/**
+ * Describes the failed operation with its fail reason (error).
+ *
+ * @see ChangeOperationsEvent
+ */
 export interface FetchOperationFail {
+    /**
+     * Operation that failed.
+     */
     readonly operation: FetchOperation;
+    /**
+     * The reason why operation failed (the thrown exception).
+     */
     readonly error: unknown;
 }
 
+/**
+ * Describes a operation to fetch graph data from a data provider.
+ *
+ * @see DataProvider
+ */
 export type FetchOperation =
     | FetchOperationElement
     | FetchOperationLink
@@ -35,8 +60,18 @@ export type FetchOperation =
     | FetchOperationLinkType
     | FetchOperationPropertyType;
 
+/**
+ * A possible `type` value for an fetch operation with a set of targets.
+ *
+ * @see FetchOperation
+ */
 export type FetchOperationTargetType = Exclude<FetchOperation['type'], 'link'>;
 
+/**
+ * A type which maps fetch operation `type` to a target type for such operation.
+ *
+ * @see FetchOperation
+ */
 export interface FetchOperationTypeToTarget {
     'element': ElementIri;
     'elementType': ElementTypeIri;
@@ -44,27 +79,69 @@ export interface FetchOperationTypeToTarget {
     'propertyType': PropertyTypeIri;
 }
 
+/**
+ * Fetch operation for an element (graph node) data.
+ */
 export interface FetchOperationElement {
+    /**
+     * Fetch operation type.
+     */
     readonly type: 'element';
+    /**
+     * Fetch operation targets.
+     */
     readonly targets: ReadonlySet<ElementIri>;
 }
 
+/**
+ * Fetch operation for links (graph edges) between elements.
+ */
 export interface FetchOperationLink {
+    /**
+     * Fetch operation type.
+     */
     readonly type: 'link';
 }
 
+/**
+ * Fetch operation for an element type data.
+ */
 export interface FetchOperationElementType {
+    /**
+     * Fetch operation type.
+     */
     readonly type: 'elementType';
+    /**
+     * Fetch operation targets.
+     */
     readonly targets: ReadonlySet<ElementTypeIri>;
 }
 
+/**
+ * Fetch operation for a link type data.
+ */
 export interface FetchOperationLinkType {
+    /**
+     * Fetch operation type.
+     */
     readonly type: 'linkType';
+    /**
+     * Fetch operation targets.
+     */
     readonly targets: ReadonlySet<LinkTypeIri>;
 }
 
+/**
+ * Fetch operation for a property type data.
+ */
 export interface FetchOperationPropertyType {
+    /**
+     * Fetch operation type.
+     */
     readonly type: 'propertyType';
+    /**
+     * Fetch operation targets.
+     */
     readonly targets: ReadonlySet<PropertyTypeIri>;
 }
 

--- a/src/editor/editLayer.tsx
+++ b/src/editor/editLayer.tsx
@@ -11,6 +11,7 @@ import { Element, VoidElement } from '../diagram/elements';
 import { SizeProvider, Vector, boundsOf, findElementAtPoint } from '../diagram/geometry';
 import { LinkLayer, LinkMarkers } from '../diagram/linkLayer';
 import { TransformedSvgCanvas } from '../diagram/paper';
+import type { MutableRenderingState } from '../diagram/renderingState';
 import { Spinner } from '../diagram/spinner';
 
 import { type WorkspaceContext, useWorkspace } from '../workspace/workspaceContext';
@@ -430,14 +431,15 @@ class EditLayerInner extends React.Component<EditLayerInnerProps, State> {
         }
 
         const transform = canvas.metrics.getTransform();
+        const renderingState = canvas.renderingState as MutableRenderingState;
         return (
             <TransformedSvgCanvas paperTransform={transform} style={{overflow: 'visible'}}>
-                <LinkMarkers renderingState={canvas.renderingState} />
+                <LinkMarkers renderingState={renderingState} />
                 {this.renderHighlight()}
                 {this.renderCanDropIndicator()}
                 {waitingForMetadata ? null : (
                     <LinkLayer model={model}
-                        renderingState={canvas.renderingState}
+                        renderingState={renderingState}
                         links={[this.temporaryLink]}
                     />
                 )}

--- a/src/editor/linkStateWidget.tsx
+++ b/src/editor/linkStateWidget.tsx
@@ -82,7 +82,7 @@ class LinkStateWidgetInner extends React.Component<LinkStateWidgetInternalProps>
             canvas.renderingState.events, 'changeLinkLabelBounds', this.scheduleUpdate
         );
         this.listener.listen(canvas.renderingState.events, 'syncUpdate', ({layer}) => {
-            if (layer === RenderingLayer.Editor) {
+            if (layer === RenderingLayer.Overlay) {
                 this.delayedUpdate.runSynchronously();
             }
         });

--- a/src/editor/overlayController.tsx
+++ b/src/editor/overlayController.tsx
@@ -26,6 +26,7 @@ import { EditLayer, DragEditOperation } from './editLayer';
 import { ElementDecorator } from './elementDecorator';
 import { LinkStateWidget } from './linkStateWidget';
 
+/** @hidden */
 export interface OverlayControllerProps extends OverlayControllerOptions {
     readonly model: DataDiagramModel;
     readonly view: SharedCanvasState;
@@ -43,7 +44,15 @@ export interface PropertyEditorOptions {
     onCancel?: () => void;
 }
 
+/**
+ * Event data for `OverlayController` events.
+ *
+ * @see OverlayController
+ */
 export interface OverlayControllerEvents {
+    /**
+     * Triggered on `openedDialog` property change.
+     */
     changeOpenedDialog: PropertyChange<OverlayController, OpenedDialog | undefined>;
 }
 
@@ -55,15 +64,30 @@ export type KnownDialogType =
     | 'findOrCreateEntity'
     | 'renameLink';
 
+/**
+ * Describes a dialog opened as an overlay for the canvas.
+ */
 export interface OpenedDialog {
+    /**
+     * Dialog target (anchor).
+     */
     readonly target: Element | Link;
     /** @hidden */
     readonly knownType: KnownDialogType | undefined;
+    /**
+     * Whether the diagram should not change selection
+     * while the dialog is opened.
+     */
     readonly holdSelection: boolean;
+    /**
+     * Handler which will be called when dialog is closed.
+     */
     readonly onClose: () => void;
 }
 
 /**
+ * Controls UI overlays for the canvases, including dialogs and tasks.
+ *
  * @category Core
  */
 export class OverlayController {
@@ -123,6 +147,11 @@ export class OverlayController {
         this.updateElementDecorator();
     }
 
+    /**
+     * Currently open dialog.
+     *
+     * Returns `undefined` if no dialog is opened.
+     */
     get openedDialog(): OpenedDialog | undefined {
         return this._openedDialog;
     }
@@ -509,8 +538,26 @@ export class OverlayController {
  * Represents a foreground canvas task.
  */
 export interface OverlayTask {
+    /**
+     * Task title to display.
+     */
     readonly title: string | undefined;
+    /**
+     * Marks the task as failed with the specified error.
+     *
+     * If set, the error will be displayed until another task
+     * will be started later.
+     *
+     * This method can be called multiple times and will not
+     * complete the task (i.e. `end()` method call is required).
+     */
     setError(error: unknown): void;
+    /**
+     * Completes the task and removes its representation from the overlay.
+     *
+     * If the task is marked with error via `setError()`, that error
+     * will be kept displaying until another task is started later.
+     */
     end(): void;
 }
 

--- a/src/editor/validation.ts
+++ b/src/editor/validation.ts
@@ -10,24 +10,52 @@ import { iterateEntitiesOf, iterateRelationsOf } from './dataElements';
 import { EditorController } from './editorController';
 
 /**
+ * Immutable validation state for the data changes from the graph authoring.
+ *
  * @category Core
  */
 export interface ValidationState {
+    /**
+     * Validation state for the entities.
+     */
     readonly elements: ReadonlyMap<ElementIri, ElementValidation>;
+    /**
+     * Validation state for the relations.
+     */
     readonly links: ReadonlyHashMap<LinkKey, LinkValidation>;
 }
 
+/**
+ * Validation state for a single entity.
+ */
 export interface ElementValidation {
+    /**
+     * Whether the entity is currently being validated.
+     */
     readonly loading: boolean;
+    /**
+     * Validation errors for the entity.
+     */
     readonly errors: ReadonlyArray<ElementError>;
 }
 
+/**
+ * Validation state for a single relation.
+ */
 export interface LinkValidation {
+    /**
+     * Whether the relation is currently being validated.
+     */
     readonly loading: boolean;
+    /**
+     * Validation errors for the relation.
+     */
     readonly errors: ReadonlyArray<LinkError>;
 }
 
 /**
+ * Utility functions to operate on validation state for the graph authoring.
+ *
  * @category Core
  */
 export namespace ValidationState {

--- a/src/forms/findOrCreateEntityForm.tsx
+++ b/src/forms/findOrCreateEntityForm.tsx
@@ -227,7 +227,7 @@ export class FindOrCreateEntityForm extends React.Component<FindOrCreateEntityFo
                 AuthoringState.addElement(editor.authoringState, target.data)
             );
         } else {
-            model.requestLinksOfType();
+            model.requestLinks();
         }
 
         const newLink = new RelationLink({

--- a/src/forms/renameLinkForm.tsx
+++ b/src/forms/renameLinkForm.tsx
@@ -22,19 +22,18 @@ export function RenameLinkForm(props: RenameLinkFormProps) {
     const linkTypeChangeStore = useEventStore(linkType?.events, 'changeData');
     const linkTypeLabel = useSyncStore(linkTypeChangeStore, () => linkType?.data?.label);
 
-    const [customLabel, setCustomLabel] = React.useState('');
+    const defaultLabel = React.useMemo(
+        () => model.locale.formatLabel(linkTypeLabel, link.typeId),
+        [link, linkTypeLabel]
+    );
 
-    const defaultLabel = React.useMemo(() => {
-        const label = renameLinkHandler?.getLabel(link)
-            ?? model.locale.formatLabel(linkTypeLabel, link.typeId);
-        return label;
-    }, [link, linkTypeLabel]);
-
-    const effectiveLabel = customLabel ? customLabel : defaultLabel;
+    const [customLabel, setCustomLabel] = React.useState(
+        renameLinkHandler?.getLabel(link) ?? defaultLabel
+    );
 
     const onApply = () => {
         if (renameLinkHandler) {
-            renameLinkHandler.setLabel(link, effectiveLabel);
+            renameLinkHandler.setLabel(link, customLabel);
         }
         onFinish();
     };
@@ -45,8 +44,10 @@ export function RenameLinkForm(props: RenameLinkFormProps) {
                 <div className={`${CLASS_NAME}__form-row`}>
                     <label>Link Label</label>
                     <input className='reactodia-form-control'
-                        value={effectiveLabel}
-                        onChange={e => setCustomLabel((e.target as HTMLInputElement).value)} />
+                        placeholder={defaultLabel}
+                        value={customLabel}
+                        onChange={e => setCustomLabel((e.target as HTMLInputElement).value)}
+                    />
                 </div>
             </div>
             <div className={`${CLASS_NAME}__controls`}>

--- a/src/forms/renameLinkForm.tsx
+++ b/src/forms/renameLinkForm.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import { useEventStore, useSyncStore } from '../coreUtils/hooks';
 
-import { useCanvas } from '../diagram/canvasApi';
 import { Link } from '../diagram/elements';
 
 import { useWorkspace } from '../workspace/workspaceContext';
@@ -17,8 +16,7 @@ export interface RenameLinkFormProps {
 export function RenameLinkForm(props: RenameLinkFormProps) {
     const {link, onFinish} = props;
 
-    const {canvas} = useCanvas();
-    const {model} = useWorkspace();
+    const {model, view: {renameLinkHandler}} = useWorkspace();
 
     const linkType = model.getLinkType(link.typeId);
     const linkTypeChangeStore = useEventStore(linkType?.events, 'changeData');
@@ -27,8 +25,7 @@ export function RenameLinkForm(props: RenameLinkFormProps) {
     const [customLabel, setCustomLabel] = React.useState('');
 
     const defaultLabel = React.useMemo(() => {
-        const {editableLabel} = canvas.renderingState.createLinkTemplate(link.typeId);
-        const label = editableLabel?.getLabel(link)
+        const label = renameLinkHandler?.getLabel(link)
             ?? model.locale.formatLabel(linkTypeLabel, link.typeId);
         return label;
     }, [link, linkTypeLabel]);
@@ -36,8 +33,9 @@ export function RenameLinkForm(props: RenameLinkFormProps) {
     const effectiveLabel = customLabel ? customLabel : defaultLabel;
 
     const onApply = () => {
-        const {editableLabel} = canvas.renderingState.createLinkTemplate(link.typeId);
-        editableLabel!.setLabel(link, effectiveLabel);
+        if (renameLinkHandler) {
+            renameLinkHandler.setLabel(link, effectiveLabel);
+        }
         onFinish();
     };
 

--- a/src/layout.worker.ts
+++ b/src/layout.worker.ts
@@ -9,7 +9,16 @@ import {
     colaRemoveOverlaps,
 } from './diagram/layoutShared';
 
+/**
+ * Provides a web worker with basic diagram layout algorithms.
+ */
 class DefaultLayouts {
+    /**
+     * Default layout algorithm, the same as `blockingDefaultLayout()`
+     * but non-blocking due to being run in a worker.
+     *
+     * @see blockingDefaultLayout()
+     */
     async defaultLayout(
         graph: LayoutGraph,
         state: LayoutState,
@@ -18,6 +27,9 @@ class DefaultLayouts {
         return blockingDefaultLayout(graph, state, options);
     }
 
+    /**
+     * Force-directed layout algorithm from [cola.js](https://ialab.it.monash.edu/webcola/).
+     */
     async forceLayout(
         graph: LayoutGraph,
         state: LayoutState,
@@ -26,6 +38,9 @@ class DefaultLayouts {
         return colaForceLayout(graph, state, options);
     }
 
+    /**
+     * Flow layout algorithm from [cola.js](https://ialab.it.monash.edu/webcola/).
+     */
     async flowLayout(
         graph: LayoutGraph,
         state: LayoutState,
@@ -34,6 +49,9 @@ class DefaultLayouts {
         return colaFlowLayout(graph, state, options);
     }
 
+    /**
+     * Remove overlaps algorithm from [cola.js](https://ialab.it.monash.edu/webcola/).
+     */
     async removeOverlaps(
         graph: LayoutGraph,
         state: LayoutState

--- a/src/templates/defaultLinkTemplate.tsx
+++ b/src/templates/defaultLinkTemplate.tsx
@@ -6,7 +6,6 @@ import { useKeyedSyncStore } from '../coreUtils/keyedObserver';
 import { PropertyTypeIri } from '../data/model';
 import { TemplateProperties } from '../data/schema';
 
-import { useCanvas } from '../diagram/canvasApi';
 import { LinkTemplate, LinkTemplateProps } from '../diagram/customization';
 import { LinkPath, LinkLabel, LinkLabelProps, LinkVertices } from '../diagram/linkLayer';
 
@@ -50,15 +49,13 @@ type CustomizedLinkLabelProps = Omit<
  */
 export function DefaultLinkPathTemplate(props: DefaultLinkPathTemplateProps) {
     const {
-        link, className, path, pathProps, getPathPosition, route,
-        editableLabel,
+        link, className, path, pathProps, markerSource, markerTarget, getPathPosition, route,
         primaryLabelProps,
         propertyLabelProps,
         propertyLabelStartLine = 1,
         prependLabels = null,
     } = props;
-    const {canvas} = useCanvas();
-    const {model} = useWorkspace();
+    const {model, view: {renameLinkHandler}} = useWorkspace();
 
     useKeyedSyncStore(subscribeLinkTypes, [link.typeId], model);
     useKeyedSyncStore(
@@ -67,7 +64,7 @@ export function DefaultLinkPathTemplate(props: DefaultLinkPathTemplateProps) {
         model
     );
 
-    const renamedLabel = editableLabel?.getLabel(link);
+    const renamedLabel = renameLinkHandler?.getLabel(link);
     let labelContent: JSX.Element | null = null;
     if (model.getLinkVisibility(link.typeId) === 'visible') {
         const textClass = `${CLASS_NAME}__label-text`;
@@ -150,8 +147,7 @@ export function DefaultLinkPathTemplate(props: DefaultLinkPathTemplateProps) {
                 renamedLabel ? `${CLASS_NAME}--renamed` : undefined,
                 className
             )}>
-            <LinkPath typeIndex={canvas.renderingState.ensureLinkTypeIndex(link.typeId)}
-                path={path}
+            <LinkPath path={path}
                 pathProps={{
                     fill: 'none',
                     ...pathProps,
@@ -160,6 +156,8 @@ export function DefaultLinkPathTemplate(props: DefaultLinkPathTemplateProps) {
                     strokeDasharray: linkState?.[TemplateProperties.LayoutOnly]
                         ? '5,5' : pathProps?.strokeDasharray,
                 }}
+                markerSource={markerSource}
+                markerTarget={markerTarget}
             />
             {labelContent}
             {link.vertices.length === 0 ? null : (

--- a/src/widgets/canvas.tsx
+++ b/src/widgets/canvas.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 
-import {
+import type { ZoomOptions } from '../diagram/canvasApi';
+import type {
     LinkRouter, LinkTemplateResolver, ElementTemplate,
 } from '../diagram/customization';
 import { Element } from '../diagram/elements';
-import { PaperArea, ZoomOptions } from '../diagram/paperArea';
-import { RenderingState } from '../diagram/renderingState';
+import { PaperArea } from '../diagram/paperArea';
+import { MutableRenderingState } from '../diagram/renderingState';
 
 import { EntityElement } from '../editor/dataElements';
 
@@ -39,7 +40,7 @@ export function Canvas(props: CanvasProps) {
         showScrollbars, zoomOptions, watermarkSvg, watermarkUrl, children,
     } = props;
 
-    const [renderingState] = React.useState(() => new RenderingState({
+    const [renderingState] = React.useState(() => new MutableRenderingState({
         model,
         shared: view,
         elementTemplateResolver: elementTemplateResolver ? (

--- a/src/widgets/connectionsMenu.tsx
+++ b/src/widgets/connectionsMenu.tsx
@@ -8,10 +8,9 @@ import { generate128BitID } from '../data/utils';
 
 import { CanvasApi, useCanvas } from '../diagram/canvasApi';
 import { defineCanvasWidget } from '../diagram/canvasWidget';
-import { changeLinkTypeVisibility } from '../diagram/commands';
+import { changeLinkTypeVisibility, placeElementsAroundTarget } from '../diagram/commands';
 import { Element, VoidElement } from '../diagram/elements';
 import { getContentFittingBox } from '../diagram/geometry';
-import { placeElementsAround } from '../diagram/layout';
 import { DiagramModel } from '../diagram/model';
 
 import { DataDiagramModel, requestElementData, restoreLinksBetweenElements } from '../editor/dataDiagramModel';
@@ -558,12 +557,12 @@ class ConnectionsMenuInner extends React.Component<ConnectionsMenuInnerProps, Me
         }
 
         canvas.renderingState.syncUpdate();
-        placeElementsAround({
+        batch.history.execute(placeElementsAroundTarget({
+            target: placeTarget,
             elements: placedElements,
-            model,
+            graph: model,
             sizeProvider: canvas.renderingState,
-            targetElement: placeTarget,
-        });
+        }));
 
         if (linkTypeId && model.getLinkVisibility(linkTypeId) === 'hidden') {
             batch.history.execute(changeLinkTypeVisibility(model, linkTypeId, 'visible'));

--- a/src/widgets/instancesSearch.tsx
+++ b/src/widgets/instancesSearch.tsx
@@ -4,13 +4,13 @@ import classnames from 'classnames';
 import { EventObserver, Events } from '../coreUtils/events';
 import { Debouncer } from '../coreUtils/scheduler';
 
-import { ElementModel, ElementIri, ElementTypeIri, LinkTypeIri, LinkedElement } from '../data/model';
-import { DataProviderLookupParams } from '../data/provider';
+import { ElementModel, ElementIri, ElementTypeIri, LinkTypeIri } from '../data/model';
+import { DataProviderLookupParams, DataProviderLookupItem } from '../data/provider';
 
 import type { CanvasApi } from '../diagram/canvasApi';
+import { placeElementsAroundTarget } from '../diagram/commands';
 import { VoidElement } from '../diagram/elements';
 import { Vector } from '../diagram/geometry';
-import { placeElementsAround } from '../diagram/layout';
 
 import { requestElementData, restoreLinksBetweenElements } from '../editor/dataDiagramModel';
 
@@ -374,7 +374,7 @@ class InstancesSearchInner extends React.Component<InstancesSearchInnerProps, St
         });
     }
 
-    private processFilterData(elements: LinkedElement[]) {
+    private processFilterData(elements: readonly DataProviderLookupItem[]) {
         const requestedAdditionalItems =
             typeof this.currentRequest!.limit === 'number' &&
             this.currentRequest!.limit > ITEMS_PER_PAGE;
@@ -433,13 +433,13 @@ class InstancesSearchInner extends React.Component<InstancesSearchInnerProps, St
             const elements = selectedEntities.map(entity => model.createElement(entity));
             canvas.renderingState.syncUpdate();
 
-            placeElementsAround({
+            batch.history.execute(placeElementsAroundTarget({
+                target,
                 elements,
-                model,
+                graph: model,
                 sizeProvider: canvas.renderingState,
-                targetElement: target,
-                preferredLinksLength: 150,
-            });
+                distance: 150,
+            }));
         } else {
             const group = new EntityGroup({
                 items: selectedEntities.map(data => ({data})),

--- a/src/widgets/linkAction.tsx
+++ b/src/widgets/linkAction.tsx
@@ -308,7 +308,7 @@ export function LinkActionRename(props: LinkActionRenameProps) {
     const {className, title} = props;
     const {link} = useLinkActionContext();
     const {canvas} = useCanvas();
-    const {overlay} = useWorkspace();
+    const {view: {renameLinkHandler}, overlay} = useWorkspace();
 
     const labelBoundsStore = useEventStore(canvas.renderingState.events, 'changeLinkLabelBounds');
     const labelBounds = useSyncStore(
@@ -316,8 +316,7 @@ export function LinkActionRename(props: LinkActionRenameProps) {
         () => canvas.renderingState.getLinkLabelBounds(link)
     );
 
-    const template = canvas.renderingState.createLinkTemplate(link.typeId);
-    if (!template.editableLabel || !labelBounds) {
+    if (!(renameLinkHandler?.canRename(link) && labelBounds)) {
         return null;
     }
 

--- a/src/widgets/linksToolbox.tsx
+++ b/src/widgets/linksToolbox.tsx
@@ -4,7 +4,8 @@ import classnames from 'classnames';
 import { Debouncer } from '../coreUtils/scheduler';
 import { EventObserver, EventTrigger } from '../coreUtils/events';
 
-import { LinkCount, LinkTypeModel } from '../data/model';
+import { LinkTypeModel } from '../data/model';
+import { DataProviderLinkCount } from '../data/provider';
 import { changeLinkTypeVisibility } from '../diagram/commands';
 import { LinkTypeVisibility } from '../diagram/elements';
 import { DiagramModel } from '../diagram/model';
@@ -351,7 +352,7 @@ class LinkTypesToolboxInner extends React.Component<LinkTypesToolboxInnerProps, 
         }
     }
 
-    private computeStateFromRequestResult(linkTypes: ReadonlyArray<LinkCount>) {
+    private computeStateFromRequestResult(linkTypes: ReadonlyArray<DataProviderLinkCount>) {
         const {workspace: {model}} = this.props;
 
         const linksOfElement: LinkTypeModel[] = [];

--- a/src/widgets/selection.tsx
+++ b/src/widgets/selection.tsx
@@ -72,7 +72,9 @@ export function Selection(props: SelectionProps) {
         let origin: PageOrigin | undefined;
         const listener = new EventObserver();
         listener.listen(canvas.events, 'pointerDown', e => {
-            if (!e.target && !e.panning && e.sourceEvent.shiftKey) {
+            const requireShift = e.source.pointerMode !== 'selection';
+            const allowSelection = e.sourceEvent.shiftKey === requireShift;
+            if (!e.target && !e.panning && allowSelection) {
                 e.sourceEvent.preventDefault();
                 const {pageX, pageY} = e.sourceEvent;
                 origin = {pageX, pageY};

--- a/src/widgets/selectionAction.tsx
+++ b/src/widgets/selectionAction.tsx
@@ -268,13 +268,15 @@ function useElementExpandedStore(model: DiagramModel, elements: ReadonlyArray<El
     }, [model.events, elements]);
 }
 
-export interface SelectionActionAnchorProps extends SelectionActionStyleProps {}
+export interface SelectionActionAnchorProps extends SelectionActionStyleProps {
+    onSelect?: (target: EntityElement, e: React.MouseEvent<HTMLAnchorElement>) => void;
+}
 
 /**
  * @category Components
  */
 export function SelectionActionAnchor(props: SelectionActionAnchorProps) {
-    const {dock, dockRow, dockColumn, className, title} = props;
+    const {dock, dockRow, dockColumn, className, title, onSelect} = props;
     const {model, canvas} = useCanvas();
     const elements = model.selection.filter((cell): cell is Element => cell instanceof Element);
     if (elements.length !== 1) {
@@ -295,7 +297,13 @@ export function SelectionActionAnchor(props: SelectionActionAnchorProps) {
             style={getDockStyle(dockRow, dockColumn)}
             href={target.iri}
             title={title ?? 'Jump to resource'}
-            onClick={e => canvas.renderingState.shared.onIriClick(target.iri, target, 'jumpToEntity', e)}
+            onClick={e => {
+                if (onSelect) {
+                    onSelect(target, e);
+                } else {
+                    canvas.renderingState.shared.onIriClick(target.iri, target, 'jumpToEntity', e);
+                }
+            }}
         />
     );
 }

--- a/src/worker-protocol.ts
+++ b/src/worker-protocol.ts
@@ -1,3 +1,4 @@
+/** @hidden */
 export interface WorkerCall {
     readonly type: 'call';
     readonly id: number;
@@ -5,12 +6,14 @@ export interface WorkerCall {
     readonly args: readonly unknown[];
 }
 
+/** @hidden */
 export interface WorkerCallSuccess {
     readonly type: 'success';
     readonly id: number;
     readonly result: unknown;
 }
 
+/** @hidden */
 export interface WorkerCallError {
     readonly type: 'error';
     readonly id: number;
@@ -20,6 +23,34 @@ export interface WorkerCallError {
 export type WorkerObject<T> = { [K in keyof T]: (...args: any[]) => Promise<any> };
 export type WorkerConstructor<A extends any[], T> = new (...initArgs: A) => WorkerObject<T>;
 
+/**
+ * Establishes a specific connection protocol between the callee (worker) and external
+ * caller (which created a worker via `new Worker(...)` constructor).
+ *
+ * The protocol assumes the worker exposes an RPC-like interface via a `class` where
+ * every public method returns a `Promise`. This interface is transparently mapped
+ * from the caller to the worker via messages.
+ *
+ * **Example**:
+ * ```ts
+ * // calc-worker.ts
+ * class Calculator {
+ *     constructor(precision: number) { ... }
+ *     add(a: number, b: number): Promise<number> { ... }
+ * }
+ *
+ * connectWorker(Calculator);
+ * 
+ * // component.ts
+ * const calcWorker = defineWorker(() => new Worker('./calc-worker.js'), [0.1]);
+ * ...
+ * function Component() {
+ *     const calc = useWorker(calcWorker);
+ *     ...
+ *     const result = await calc.add(2, 3);
+ * }
+ * ```
+ */
 export function connectWorker<A extends any[], T>(factory: WorkerConstructor<A, T>): void {
     let handler: Record<string, (...args: unknown[]) => Promise<any>>;
     onmessage = async e => {

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -43,6 +43,7 @@ export { defineCanvasWidget } from './diagram/canvasWidget';
 export {
     RestoreGeometry, setElementState, setElementExpanded, setLinkState,
     changeLinkTypeVisibility, restoreCapturedLinkGeometry, restoreViewport,
+    placeElementsAroundTarget,
 } from './diagram/commands';
 export * from './diagram/customization';
 export {
@@ -51,12 +52,12 @@ export {
     Cell, VoidElement, LinkTypeVisibility,
 } from './diagram/elements';
 export * from './diagram/geometry';
+export { CellsChangedEvent } from './diagram/graph';
 export * from './diagram/history';
 export {
     CalculatedLayout, LayoutGraph, LayoutState, LayoutNode, LayoutLink,
     LayoutTypeProvider, LayoutFunction,
-    calculateLayout, applyLayout, uniformGrid, calculateAveragePosition,
-    placeElementsAround, translateToPositiveQuadrant,
+    calculateLayout, applyLayout, uniformGrid, translateToPositiveQuadrant,
 } from './diagram/layout';
 export { DefaultLayouts, defineLayoutWorker } from './diagram/layoutDefault';
 export {
@@ -74,11 +75,10 @@ export { type DiagramModel, DiagramModelEvents, GraphStructure, LocaleFormatter 
 export {
     PaperTransform, TransformedSvgCanvas, TransformedSvgCanvasProps, paneTopLeft, totalPaneSize,
 } from './diagram/paper';
-export { ZoomOptions } from './diagram/paperArea';
-export { type RenderingState, RenderingStateEvents, RenderingLayer } from './diagram/renderingState';
+export { RenderingState, RenderingStateEvents, RenderingLayer } from './diagram/renderingState';
 export {
     type SharedCanvasState, SharedCanvasStateEvents, CellHighlighter, ElementDecoratorResolver,
-    FindCanvasEvent, IriClickEvent, IriClickIntent,
+    FindCanvasEvent, IriClickEvent, IriClickIntent, RenameLinkToLinkStateHandler,
 } from './diagram/sharedCanvasState';
 export { Spinner, SpinnerProps, HtmlSpinner } from './diagram/spinner';
 
@@ -104,7 +104,7 @@ export {
     FetchOperationElement, FetchOperationLink, FetchOperationElementType,
     FetchOperationLinkType, FetchOperationPropertyType,
 } from './editor/dataFetcher';
-export { EditorOptions, EditorEvents, EditorController } from './editor/editorController';
+export { EditorEvents, EditorController } from './editor/editorController';
 export { DragEditOperation, DragEditConnect, DragEditMoveEndpoint } from './editor/editLayer';
 export {
     subscribeElementTypes, subscribeLinkTypes, subscribePropertyTypes,
@@ -195,7 +195,7 @@ export {
     Workspace, WorkspaceProps, LoadedWorkspace, LoadedWorkspaceParams, useLoadedWorkspace,
 } from './workspace/workspace';
 export {
-    WorkspaceContext, WorkspaceEventHandler, WorkspaceEventKey, WorkspacePerformLayoutParams,
+    WorkspaceContext, WorkspaceEventKey, WorkspacePerformLayoutParams,
     WorkspaceGroupParams, WorkspaceUngroupAllParams, WorkspaceUngroupSomeParams,
     ProcessedTypeStyle, useWorkspace,
 } from './workspace/workspaceContext';


### PR DESCRIPTION
* Add `CanvasApi.zoomOptions` getter;
* Add `CanvasApi.{pointerMode, setPointerMode}`, support in `Selection` component as well;
* Add `onSelect` handler to `SelectionActionAnchor` props;
* Allow to change `EditorController.validationApi` in runtime, track changes in `WorkspaceProps`;
* **[Breaking]** Change `placeElementsAround()` function into `placeElementsAroundTarget()` command;
* **[Breaking]** Replace `LinkTemplateProps.typeIndex` with `markerSource` and `markerTarget` properties;
* **[Breaking]** Replace `EditableLabel` on the link template by a separate `RenameLinkHandler`;
* Minor runtime changes:
  - change `DefaultLinkRouter` positional option `gap` into options object with `gap` property;
  - remove unused `LinkRedrawLevel` type with corresponding parameters;
  - remove `RenderingLayer.{FirstToUpdate, LastToUpdate}`, rename `RenderingLayer.Editor` to `Overlay`;
  - rename `RestoreGeometry.captureElementsAndLinks()` to `capturePartial()`;
* Additional type-only changes:
  - expose only read-only state from `RenderingState` interface;
  - deprecate `WorkspaceProps.onIriClick`, `SharedCanvasState.onIriClick()`;
  - deprecate `DataDiagramModel.requestLinksOfType()`, replaced by `requestLinks()`;
