### PR TITLE
Support incremental links loading from `DataProvider`

### DIFF
--- a/src/data/composite/composite.ts
+++ b/src/data/composite/composite.ts
@@ -120,7 +120,8 @@ export class CompositeDataProvider implements DataProvider {
     }
 
     links(params: {
-        elementIds: ReadonlyArray<ElementIri>;
+        targetElements: ReadonlyArray<ElementIri>;
+        pairedElements: ReadonlyArray<ElementIri>;
         linkTypeIds?: ReadonlyArray<LinkTypeIri>;
         signal?: AbortSignal;
     }): Promise<LinkModel[]> {

--- a/src/data/decorated/decoratedDataProvider.ts
+++ b/src/data/decorated/decoratedDataProvider.ts
@@ -122,7 +122,8 @@ export class DecoratedDataProvider implements DataProvider {
     }
 
     links(params: {
-        elementIds: ReadonlyArray<ElementIri>;
+        targetElements: ReadonlyArray<ElementIri>;
+        pairedElements: ReadonlyArray<ElementIri>;
         linkTypeIds?: ReadonlyArray<LinkTypeIri>;
         signal?: AbortSignal;
     }): Promise<LinkModel[]> {

--- a/src/data/decorated/emptyDataProvider.ts
+++ b/src/data/decorated/emptyDataProvider.ts
@@ -61,7 +61,8 @@ export class EmptyDataProvider implements DataProvider {
     }
 
     links(params: {
-        elementIds: readonly ElementIri[];
+        targetElements: ReadonlyArray<ElementIri>;
+        pairedElements: ReadonlyArray<ElementIri>;
         linkTypeIds?: readonly LinkTypeIri[] | undefined;
         signal?: AbortSignal | undefined;
     }): Promise<LinkModel[]> {

--- a/src/data/decorated/indexedDbCachedProvider.ts
+++ b/src/data/decorated/indexedDbCachedProvider.ts
@@ -299,7 +299,8 @@ export class IndexedDbCachedProvider implements DataProvider {
     }
 
     links(params: {
-        elementIds: readonly ElementIri[];
+        targetElements: ReadonlyArray<ElementIri>;
+        pairedElements: ReadonlyArray<ElementIri>;
         linkTypeIds?: readonly LinkTypeIri[] | undefined;
         signal?: AbortSignal | undefined;
     }): Promise<LinkModel[]> {

--- a/src/data/provider.ts
+++ b/src/data/provider.ts
@@ -93,13 +93,20 @@ export interface DataProvider {
     }): Promise<Map<ElementIri, ElementModel>>;
 
     /**
-     * Get all links between specified elements.
+     * Get all links between two specified sets of entities (bipartite graph links).
+     *
+     * To get all links between all elements in the set, it is possible to
+     * pass the same set to both `targetElements` and `pairedElements`.
      */
     links(params: {
         /**
-         * Target elements to query links between.
+         * First set of entities to get links between them and `pairedElements`.
          */
-        elementIds: ReadonlyArray<ElementIri>;
+        targetElements: ReadonlyArray<ElementIri>;
+        /**
+         * Second set of entities to get links between them and `targetElements`.
+         */
+        pairedElements: ReadonlyArray<ElementIri>;
         /**
          * Return only links with specified types.
          */

--- a/src/data/sparql/responseHandler.ts
+++ b/src/data/sparql/responseHandler.ts
@@ -310,15 +310,14 @@ interface MutableLinkModel {
 }
 
 export function getLinksInfo(
-    response: SparqlResponse<LinkBinding>,
+    bindings: ReadonlyArray<LinkBinding>,
     types: ReadonlyMap<ElementIri, ReadonlySet<ElementTypeIri>> = EMPTY_MAP,
     linkByPredicateType: ReadonlyMap<string, readonly LinkConfiguration[]> = EMPTY_MAP,
     openWorldLinks: boolean = true
 ): LinkModel[] {
-    const sparqlLinks = response.results.bindings;
     const links = new HashMap<LinkModel, MutableLinkModel>(hashLink, equalLinks);
 
-    for (const binding of sparqlLinks) {
+    for (const binding of bindings) {
         const model: MutableLinkModel = {
             sourceId: binding.source.value as ElementIri,
             linkTypeId: binding.type.value as LinkTypeIri,

--- a/src/data/sparql/sparqlDataProviderSettings.ts
+++ b/src/data/sparql/sparqlDataProviderSettings.ts
@@ -122,10 +122,17 @@ export interface SparqlDataProviderSettings {
     elementInfoQuery: string;
 
     /**
-     * SELECT query to retrieve all links between specified elements.
+     * SELECT query to retrieve links between specified `sourceIris` and
+     * `targetIris` sets of entities.
+     *
+     * For backwards compatibility, `${ids}` placeholder variable with
+     * combined set of entities can be used; in that case incremental
+     * link querying will be disabled.
      *
      * Parametrized variables:
-     *   - `${ids}` VALUES clause content with element IRIs
+     *   - `${sourceIris}` VALUES clause content with source entity IRIs
+     *   - `${targetIris}` VALUES clause content with target entity IRIs
+     *   - `${ids}` VALUES clause content with all entity IRIs (for compatibility)
      *   - `${propLanguageFilter}` property value filter based on `filterOnlyLanguages`
      *   - `${linkConfigurations}`
      *
@@ -374,8 +381,8 @@ export const RdfSettings: SparqlDataProviderSettings = {
     linksInfoQuery: `SELECT ?source ?type ?target
             WHERE {
                 \${linkConfigurations}
-                VALUES (?source) {\${ids}}
-                VALUES (?target) {\${ids}}
+                VALUES (?source) {\${sourceIris}}
+                VALUES (?target) {\${targetIris}}
             }`,
 
     defaultPrefix: '',

--- a/src/editor/dataFetcher.ts
+++ b/src/editor/dataFetcher.ts
@@ -305,14 +305,16 @@ export class DataFetcher {
     };
 
     fetchLinks(
-        elementIris: ReadonlyArray<ElementIri>,
+        targetElements: ReadonlyArray<ElementIri>,
+        pairedElements: ReadonlyArray<ElementIri>,
         linkTypeIris?: ReadonlyArray<LinkTypeIri>
     ): Promise<LinkModel[]> {
         const operation: FetchOperationLink = {
             type: 'link',
         };
         const task = this.dataProvider.links({
-            elementIds: elementIris,
+            targetElements,
+            pairedElements,
             linkTypeIds: linkTypeIris,
         });
         this.addOperation(operation, task);

--- a/src/forms/findOrCreateEntityForm.tsx
+++ b/src/forms/findOrCreateEntityForm.tsx
@@ -227,7 +227,7 @@ export class FindOrCreateEntityForm extends React.Component<FindOrCreateEntityFo
                 AuthoringState.addElement(editor.authoringState, target.data)
             );
         } else {
-            model.requestLinks();
+            model.requestLinks({addedElements: [elementValue.value.id]});
         }
 
         const newLink = new RelationLink({

--- a/src/forms/linkTypeSelector.tsx
+++ b/src/forms/linkTypeSelector.tsx
@@ -197,7 +197,8 @@ export function validateLinkType(
         return Promise.resolve({error: 'The link already exists.', allowChange: false});
     }
     return model.dataProvider.links({
-        elementIds: [currentLink.sourceId, currentLink.targetId],
+        targetElements: [currentLink.sourceId],
+        pairedElements: [currentLink.targetId],
         linkTypeIds: [currentLink.linkTypeId],
     }).then((links): Pick<LinkValue, 'error' | 'allowChange'> => {
         const alreadyExists = links.some(link => equalLinks(link, currentLink));

--- a/src/widgets/connectionsMenu.tsx
+++ b/src/widgets/connectionsMenu.tsx
@@ -645,7 +645,9 @@ class ConnectionsMenuInner extends React.Component<ConnectionsMenuInnerProps, Me
         }
 
         batch.history.execute(requestElementData(model, elementIris));
-        batch.history.execute(restoreLinksBetweenElements(model));
+        batch.history.execute(restoreLinksBetweenElements(model, {
+            addedElements: elementIris,
+        }));
         batch.store();
 
         triggerWorkspaceEvent(WorkspaceEventKey.editorAddElements);

--- a/src/widgets/dropOnCanvas.tsx
+++ b/src/widgets/dropOnCanvas.tsx
@@ -41,7 +41,9 @@ export function DropOnCanvas(props: DropOnCanvasProps) {
                 const placedElements = placeElements(iris, e.position, canvas, model);
                 const irisToLoad = placedElements.map(elem => elem.iri);
                 batch.history.execute(requestElementData(model, irisToLoad));
-                batch.history.execute(restoreLinksBetweenElements(model));
+                batch.history.execute(restoreLinksBetweenElements(model, {
+                    addedElements: iris,
+                }));
                 batch.store();
     
                 if (placedElements.length > 0) {

--- a/src/widgets/instancesSearch.tsx
+++ b/src/widgets/instancesSearch.tsx
@@ -505,8 +505,9 @@ class InstancesSearchInner extends React.Component<InstancesSearchInnerProps, St
             });
         }
 
-        batch.history.execute(requestElementData(model, Array.from(selection)));
-        batch.history.execute(restoreLinksBetweenElements(model));
+        const addedElements = Array.from(selection);
+        batch.history.execute(requestElementData(model, addedElements));
+        batch.history.execute(restoreLinksBetweenElements(model, {addedElements}));
 
         batch.store();
     }


### PR DESCRIPTION
* **[Breaking]** Change `DataProvider.links()` contract to return links between two sets of elements to allow partial link requests;
* Extend `SparqlDataProviderSettings.linksInfoQuery` to support partial link queries (with backwards compatibility fallback);
* Pass `addedElements` to `DataDiagramModel.requestLinks()` to only load links to the added elements and between them;