### PR TITLE
Support request chunking in `SparqlDataProvider.links()`

### DIFF
--- a/src/data/sparql/requestChunking.ts
+++ b/src/data/sparql/requestChunking.ts
@@ -1,25 +1,108 @@
-import type { ElementIri } from '../model';
-
-export function validateChunkSize(chunkSize: number | undefined): boolean {
-    if (typeof chunkSize === 'number') {
-        return chunkSize === Infinity || (
-            Number.isSafeInteger(chunkSize) && chunkSize > 0
-        );
+export function* chunkArray<T>(
+    items: readonly T[],
+    measure: (item: T) => number,
+    maxChunkSize: number
+): Iterable<readonly T[]> {
+    if (!Number.isFinite(maxChunkSize)) {
+        yield items;
+        return;
     }
-    return true;
+    const chunk: T[] = [];
+    let chunkSize = 0;
+    for (const item of items) {
+        const addedSize = measure(item);
+        if (chunkSize > 0 && chunkSize + addedSize > maxChunkSize) {
+            yield [...chunk];
+            chunk.length = 0;
+            chunkSize = 0;
+        }
+        chunk.push(item);
+        chunkSize += addedSize;
+    }
+    if (chunkSize > 0) {
+        yield chunk;
+    }
 }
 
-export async function processChunked<T extends string>(
-    items: readonly T[],
-    callback: (batch: readonly T[]) => Promise<void>,
-    chunkSize: number
-): Promise<void> {
-    if (!Number.isFinite(chunkSize)) {
-        return callback(items);
+export interface DirectedChunk<T> {
+    readonly sources: ReadonlyArray<T>;
+    readonly targets: ReadonlyArray<T>;
+}
+
+export function* chunkUndirectedCrossProduct<T>(
+    main: ReadonlyArray<T>,
+    paired: ReadonlyArray<T>,
+    measure: (item: T) => number,
+    maxChunkSize: number
+): Iterable<DirectedChunk<T>> {
+    if (main.length < paired.length) {
+        [main, paired] = [paired, main];
     }
-    const tasks: Array<Promise<void>> = [];
-    for (let offset = 0; offset < items.length; offset += chunkSize) {
-        tasks.push(callback(items.slice(offset, offset + chunkSize)));
+
+    const pairedSet = new Set(paired);
+    const selfSet = new Set<T>();
+    for (const item of main) {
+        if (pairedSet.has(item)) {
+            selfSet.add(item);
+        }
     }
-    await Promise.all(tasks);
+
+    yield* chunkDirectedCrossProduct(main, paired, measure, maxChunkSize);
+    yield* chunkDirectedCrossProduct(
+        paired,
+        main,
+        measure,
+        maxChunkSize,
+        pairedSet.size === selfSet.size ? selfSet : undefined
+    );
+}
+
+function* chunkDirectedCrossProduct<T>(
+    from: ReadonlyArray<T>,
+    to: ReadonlyArray<T>,
+    measure: (item: T) => number,
+    maxChunkSize: number,
+    excludedTargets?: ReadonlySet<T>
+): Iterable<DirectedChunk<T>> {
+    const halfSize = Math.ceil(maxChunkSize / 2);
+
+    const sources = new Set<T>();
+    const targets: T[] = [];
+    let sourceSize = 0;
+    let targetSize = 0;
+
+    function popPairedChunk(): DirectedChunk<T> {
+        const chunk: DirectedChunk<T> = {
+            sources: [...sources],
+            targets: [...targets],
+        };
+        targets.length = 0;
+        targetSize = 0;
+        return chunk;
+    }
+
+    for (let i = 0; i < from.length; i++) {
+        const fromItem = from[i];
+        sources.add(fromItem);
+        sourceSize += measure(fromItem);
+        if (sourceSize >= halfSize || i === from.length - 1) {
+            for (const toItem of to) {
+                if (excludedTargets && excludedTargets.has(toItem)) {
+                    continue;
+                }
+                const addedSize = measure(toItem);
+                if (targetSize > 0 && sourceSize + targetSize + addedSize > maxChunkSize) {
+                    yield popPairedChunk();
+                }
+                targets.push(toItem);
+                
+                targetSize += addedSize;
+            }
+            if (targetSize > 0) {
+                yield popPairedChunk();
+            }
+            sources.clear();
+            sourceSize = 0;
+        }
+    }
 }

--- a/test/data/requestChunking.test.ts
+++ b/test/data/requestChunking.test.ts
@@ -1,32 +1,186 @@
 import { describe, expect, it } from 'vitest';
 
-import { validateChunkSize } from '../../src/data/sparql/requestChunking';
+import { HashSet } from '../../src/coreUtils/hashMap';
+import {
+    DirectedChunk, chunkUndirectedCrossProduct,
+} from '../../src/data/sparql/requestChunking';
 
-describe('validateChunkSize()', () => {
-    it('accepts positive integer chunk sizes', () => {
-        expect(validateChunkSize(1)).toBe(true);
-        expect(validateChunkSize(2)).toBe(true);
-        expect(validateChunkSize(10)).toBe(true);
-        expect(validateChunkSize(211)).toBe(true);
-        expect(validateChunkSize(100201)).toBe(true);
-        expect(validateChunkSize(2_000_000_000)).toBe(true);
-        expect(validateChunkSize(Number.MAX_SAFE_INTEGER)).toBe(true);
+describe('chunkUndirectedCrossProduct()', () => {
+    it('handles cases with too small chunk size', () => {
+        expect(Array.from(
+            chunkUndirectedCrossProduct([1], [2], measureSingle, 0))
+        ).toEqual(
+            [
+                {sources: [1], targets: [2]},
+                {sources: [2], targets: [1]},
+            ] satisfies ReadonlyArray<DirectedChunk<number>>
+        );
+
+        expect(Array.from(
+            chunkUndirectedCrossProduct([0, 1], [2], measureSingle, 0))
+        ).toEqual(
+            [
+                {sources: [0], targets: [2]},
+                {sources: [1], targets: [2]},
+                {sources: [2], targets: [0]},
+                {sources: [2], targets: [1]},
+            ] satisfies ReadonlyArray<DirectedChunk<number>>
+        );
+
+        expect(Array.from(
+            chunkUndirectedCrossProduct([0, 1], [0, 2], measureSingle, 0))
+        ).toEqual(
+            [
+                {sources: [0], targets: [0]},
+                {sources: [0], targets: [2]},
+                {sources: [1], targets: [0]},
+                {sources: [1], targets: [2]},
+                {sources: [0], targets: [0]},
+                {sources: [0], targets: [1]},
+                {sources: [2], targets: [0]},
+                {sources: [2], targets: [1]},
+            ] satisfies ReadonlyArray<DirectedChunk<number>>
+        );
     });
 
-    it('rejects zero and negative chunk sizes', () => {
-        expect(validateChunkSize(0)).toBe(false);
-        expect(validateChunkSize(-1)).toBe(false);
-        expect(validateChunkSize(-10)).toBe(false);
-        expect(validateChunkSize(-100_000)).toBe(false);
-        expect(validateChunkSize(-Number.MAX_SAFE_INTEGER)).toBe(false);
-        expect(validateChunkSize(-Infinity)).toBe(false);
+    it('omits self-referenced items from targets if possible', () => {
+        const main = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+        const paired = [0, 1, 2, 3, 4];
+        const result = Array.from(chunkUndirectedCrossProduct(main, paired, measureSingle, 100));
+        expect(result).toEqual(
+            [
+                {
+                    sources: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+                    targets: [0, 1, 2, 3, 4],
+                },
+                {
+                    sources: [0, 1, 2, 3, 4],
+                    targets: [5, 6, 7, 8, 9],
+                },
+            ] satisfies ReadonlyArray<DirectedChunk<number>>
+        );
     });
 
-    it('rejects non-integer chunk sizes', () => {
-        expect(validateChunkSize(0.5)).toBe(false);
-        expect(validateChunkSize(100.1)).toBe(false);
-        expect(validateChunkSize(-42.7)).toBe(false);
-        expect(validateChunkSize(Number.MAX_SAFE_INTEGER * 2)).toBe(false);
-        expect(validateChunkSize(Number.NaN)).toBe(false);
+    it('puts everything in a single chunk per direction given enough size', () => {
+        const main = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+        const paired = [0, 1, 2, 3, 4, 10, 11, 12];
+        const result = Array.from(chunkUndirectedCrossProduct(main, paired, measureSingle, 100));
+        expect(result).toEqual(
+            [
+                {
+                    sources: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+                    targets: [0, 1, 2, 3, 4, 10, 11, 12],
+                },
+                {
+                    sources: [0, 1, 2, 3, 4, 10, 11, 12],
+                    targets: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+                },
+            ] satisfies ReadonlyArray<DirectedChunk<number>>
+        );
     });
+
+    it('splits request into multiple chunks', () => {
+        const main = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+        const paired = [0, 1, 2, 3, 4, 10, 11, 12];
+        const result = Array.from(chunkUndirectedCrossProduct(main, paired, measureSingle, 14));
+        expect(result).toEqual(
+            [
+                {
+                    sources: [0, 1, 2, 3, 4, 5, 6],
+                    targets: [0, 1, 2, 3, 4, 10, 11],
+                },
+                {
+                    sources: [0, 1, 2, 3, 4, 5, 6],
+                    targets: [12],
+                },
+                {
+                    sources: [7, 8, 9],
+                    targets: [0, 1, 2, 3, 4, 10, 11, 12],
+                },
+                {
+                    sources: [0, 1, 2, 3, 4, 10, 11],
+                    targets: [0, 1, 2, 3, 4, 5, 6],
+                },
+                {
+                    sources: [0, 1, 2, 3, 4, 10, 11],
+                    targets: [7, 8, 9],
+                },
+                {
+                    sources: [12],
+                    targets: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+                },
+            ] satisfies ReadonlyArray<DirectedChunk<number>>
+        );
+    });
+
+    it.for([
+        [0, 1, 0, 0, 0],
+        [0, 1, 1, 0, 2],
+        [1, 1, 0, 0, 3],
+        [0, 2, 1, 0, 4],
+        [1, 1, 1, 0, 8],
+        [5, 5, 3, 100, 2],
+        [5, 5, 3, 14, 6],
+        [100, 0, 1, 50, 23],
+        [200, 50, 20, 100, 49],
+    ])(
+        'splits [common: %i, main: %i, paired: %i] with max size %i into %i chunks',
+        ([selfCount, mainCount, pairedCount, chunkSize, expectedChunkCount]) => {
+            const main: number[] = [];
+            const paired: number[] = [];
+
+            let nextItem = 0;
+            for (let i = 0; i < selfCount; i++) {
+                const item = nextItem++;
+                main.push(item);
+                paired.push(item);
+            }
+
+            for (let i = 0; i < mainCount; i++) {
+                const item = nextItem++;
+                main.push(item);
+            }
+
+            for (let i = 0; i < pairedCount; i++) {
+                const item = nextItem++;
+                paired.push(item);
+            }
+
+            const result = Array.from(chunkUndirectedCrossProduct(main, paired, measureSingle, chunkSize));
+            expect(Array.from(computeNonCoveredLinks(main, paired, result))).to.have.members([]);
+            expect(result).to.have.length(expectedChunkCount);
+        }
+    );
 });
+
+function measureSingle(): number {
+    return 1;
+}
+
+function computeNonCoveredLinks(
+    main: ReadonlyArray<number>,
+    paired: ReadonlyArray<number>,
+    result: ReadonlyArray<DirectedChunk<number>>
+): HashSet<readonly [number, number]> {
+    const allPairs = new HashSet<readonly [number, number]>(
+        p => (p[0] + Math.imul(p[1], 1027)) | 0,
+        (a, b) => a[0] === b[0] && a[1] === b[1]
+    );
+
+    for (const a of main) {
+        for (const b of paired) {
+            allPairs.add([a, b]);
+            allPairs.add([b, a]);
+        }
+    }
+
+    for (const chunk of result) {
+        for (const source of chunk.sources) {
+            for (const targets of chunk.targets) {
+                allPairs.delete([source, targets]);
+            }
+        }
+    }
+
+    return allPairs;
+}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -7,6 +7,7 @@ export default defineConfig({
             provider: 'playwright',
             enabled: true,
             name: 'chromium',
+            screenshotFailures: false,
         },
     }
 });


### PR DESCRIPTION
* Change `SparqlDataProviderOptions.chunkSize` into `chunk` options object wth `maxSize`, `unit` properties;
* Enable chunking only for GET query method by default with `2500` character limit;