### PR TITLE
Cache links via perfect mirroring in `IndexedDdCachedProvider`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ function BasicExample() {
 ```
 Look for more examples in the [documentation](https://reactodia.github.io/docs/category/examples).
 
+## Development
+
+### Tests
+
+The library uses [Vitest](https://vitest.dev/) as a testing framework: run `npm run test` to execute all tests.
+
+See [Vitest Debugging](https://vitest.dev/guide/debugging) documentation page for an integrated debugger setup for the tests (e.g. VSCode debugger).
+
 ## License
 
 The library is distributed under LGPL-2.1 or (at your option) any later version.

--- a/src/data/decorated/adjacencyBlocks.ts
+++ b/src/data/decorated/adjacencyBlocks.ts
@@ -1,0 +1,96 @@
+import { HashMap } from '../../coreUtils/hashMap';
+import { hashFnv32a } from '../utils';
+
+export type AdjacencyRange<K> = ReadonlySet<K>;
+
+export interface AdjacencyBlock<K> {
+    readonly sources: AdjacencyRange<K>;
+    readonly targets: AdjacencyRange<K>;
+}
+
+export function subtractAdjacencyBlocks<K extends string | number>(
+    base: AdjacencyBlock<K>,
+    disjointBySources: ReadonlyArray<AdjacencyBlock<K>>
+): Array<AdjacencyBlock<K>> {
+    const leftoverSources = new Set(base.sources);
+    interface PartialBlock {
+        readonly sources: Set<K>;
+        readonly targets: AdjacencyRange<K>;
+    }
+    const partialBlocks = new HashMap<AdjacencyRange<K>, PartialBlock>(hashRange, sameRange);
+    const orderedBlocks: PartialBlock[] = [];
+
+    const addBlock = (sources: AdjacencyRange<K>, targets: AdjacencyRange<K>) => {
+        let block = partialBlocks.get(targets);
+        if (block) {
+            for (const source of sources) {
+                block.sources.add(source);
+            }
+        } else {
+            block = {
+                targets,
+                sources: new Set(sources),
+            };
+            partialBlocks.set(targets, block);
+            orderedBlocks.push(block);
+        }
+    };
+
+    for (const block of disjointBySources) {
+        for (const foundSource of block.sources) {
+            leftoverSources.delete(foundSource);
+        }
+
+        const leftoverTargets = new Set(base.targets);
+        for (const foundTarget of block.targets) {
+            leftoverTargets.delete(foundTarget);
+        }
+
+        if (leftoverTargets.size > 0) {
+            addBlock(block.sources, leftoverTargets);
+        }
+    }
+
+    if (leftoverSources.size > 0) {
+        addBlock(leftoverSources, base.targets);
+    }
+
+    return orderedBlocks;
+}
+
+function hashRange<K extends string | number>(range: AdjacencyRange<K>): number {
+    let hash = 0;
+    for (const item of range) {
+        hash = (hash | 0) + (hashFnv32a(String(item)) | 0);
+    }
+    return hash | 0;
+}
+
+function sameRange<K>(a: AdjacencyRange<K>, b: AdjacencyRange<K>): boolean {
+    if (a.size !== b.size) {
+        return false;
+    }
+    for (const item of a) {
+        if (!b.has(item)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+export async function hashAdjacencyRange<K extends string>(range: AdjacencyRange<K>): Promise<string> {
+    const keys = Array.from(range).sort();
+    const hashes = new Uint8Array(keys.length * 32);
+    const encoder = new TextEncoder();
+    await Promise.all(keys.map(async (key, i) => {
+        const encodedKey = encoder.encode(key);
+        const hashBytes = await window.crypto.subtle.digest('SHA-256', encodedKey);
+        hashes.set(new Uint8Array(hashBytes), i * 32);
+    }));
+    const totalHashBytes = await window.crypto.subtle.digest('SHA-256', hashes);
+    const totalHashHex = Array.from(
+        new Uint8Array(totalHashBytes),
+        b => b.toString(16).padStart(2, '0')
+    ).join('');
+    return totalHashHex;
+}

--- a/src/data/model.ts
+++ b/src/data/model.ts
@@ -42,7 +42,7 @@ export interface ElementTypeGraph {
  * @category Data
  * @see ElementTypeGraph
  */
-export type SubtypeEdge = readonly [ElementTypeIri, ElementTypeIri];
+export type SubtypeEdge = readonly [derived: ElementTypeIri, base: ElementTypeIri];
 
 /**
  * Element (graph node) data.

--- a/test/data/adjacencyBlocks.test.ts
+++ b/test/data/adjacencyBlocks.test.ts
@@ -1,0 +1,79 @@
+import { expect, describe, it } from 'vitest';
+
+import {
+    AdjacencyBlock, subtractAdjacencyBlocks, hashAdjacencyRange,
+} from '../../src/data/decorated/adjacencyBlocks';
+
+describe('subtractAdjacencyBlocks()', () => {
+    it('computes adjacency block extensions', () => {
+        const result = subtractAdjacencyBlocks(
+            block([1, 2, 3, 5, 7, 9, 11, 17], [2, 3, 4, 8, 9]),
+            [
+                block([1, 2], [1, 2, 3, 4, 5]),
+                block([3], [1, 2, 3, 4, 5, 6, 7, 8, 9]),
+                block([5, 7, 9], [3, 4, 7, 8]),
+            ]
+        );
+        expect(result).toEqual([
+            block([1, 2], [8, 9]),
+            block([5, 7, 9], [2, 9]),
+            block([11, 17], [2, 3, 4, 8, 9]),
+        ] satisfies ReturnType<typeof subtractAdjacencyBlocks>);
+    });
+
+    it('groups blocks with same result targets', () => {
+        const result = subtractAdjacencyBlocks(
+            block([1, 2, 3, 5, 7, 9, 11, 13, 15, 17], [2, 3, 4, 8, 9]),
+            [
+                block([1, 2], [1, 2, 3, 4, 5]),
+                block([3], [1, 2, 3, 4, 5, 6, 7, 8, 9]),
+                block([5, 7, 9], [2, 3, 4, 11]),
+                block([11], [1, 2, 9]),
+                block([13], [2, 9, 11]),
+                block([15], [1, 5, 7]),
+            ]
+        );
+        expect(result).toEqual([
+            block([1, 2, 5, 7, 9], [8, 9]),
+            block([11, 13], [3, 4, 8]),
+            block([15, 17], [2, 3, 4, 8, 9]),
+        ] satisfies ReturnType<typeof subtractAdjacencyBlocks>);
+    });
+});
+
+type TestBlock = AdjacencyBlock<number>;
+
+function block(
+    sources: readonly number[],
+    targets: readonly number[]
+): TestBlock {
+    return {
+        sources: new Set(sources),
+        targets: new Set(targets),
+    };
+}
+
+describe('hashAdjacencyRange()', () => {
+    it('produces a consistent content hash for ranges', async () => {
+        expect(await hashAdjacencyRange(new Set([]))).toEqual(
+            'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+        );
+        expect(await hashAdjacencyRange(new Set([]))).toEqual(
+            'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+        );
+        expect(await hashAdjacencyRange(new Set([
+            'http://example.com/sourceA',
+            'http://example.com/sourceB',
+            'http://example.com/sourceC',
+        ]))).toEqual(
+            '19fabb0ef72a478af74fe009feba1d856965aeef43ffc54a57188a5126f79d08'
+        );
+        expect(await hashAdjacencyRange(new Set([
+            'http://example.com/sourceC',
+            'http://example.com/sourceA',
+            'http://example.com/sourceB',
+        ]))).toEqual(
+            '19fabb0ef72a478af74fe009feba1d856965aeef43ffc54a57188a5126f79d08'
+        );
+    });
+});

--- a/test/data/indexedDbCachedProvider.test.ts
+++ b/test/data/indexedDbCachedProvider.test.ts
@@ -1,0 +1,518 @@
+import { expect, describe, it, vi } from 'vitest';
+
+import { IndexedDbCachedProvider } from '../../src/data/decorated/indexedDbCachedProvider';
+import type {
+    ElementIri, ElementTypeIri, LinkModel, LinkTypeIri, PropertyTypeIri,
+} from '../../src/data/model';
+import {
+    MockDataProvider, element, elementType, linkType, propertyType, missing,
+} from '../mock/mockDataProvider';
+
+describe('IndexedDbCachedProvider', () => {
+    it('caches data once for known element/link types', async () => {
+        const baseProvider = new MockDataProvider();
+        const knownElementTypesSpy = vi.spyOn(baseProvider, 'knownElementTypes');
+        const knownLinkTypesSpy = vi.spyOn(baseProvider, 'knownLinkTypes');
+
+        const controller = new AbortController();
+        try {
+            const provider = new IndexedDbCachedProvider({
+                baseProvider,
+                dbName: 'test',
+                closeSignal: controller.signal,
+            });
+
+            await provider.clearCache();
+
+            await provider.knownElementTypes({});
+            await provider.knownLinkTypes({});
+
+            expect(knownElementTypesSpy.mock.calls.length).toEqual(1);
+            expect(knownLinkTypesSpy.mock.calls.length).toEqual(1);
+
+            await provider.knownElementTypes({});
+            await provider.knownLinkTypes({});
+
+            expect(knownElementTypesSpy.mock.calls.length).toEqual(1);
+            expect(knownLinkTypesSpy.mock.calls.length).toEqual(1);
+        } finally {
+            controller.abort();
+        }
+    });
+
+    it('caches data for elements', async () => {
+        const baseProvider = new MockDataProvider();
+        const elementsSpy = vi.spyOn(baseProvider, 'elements');
+
+        const controller = new AbortController();
+        try {
+            const provider = new IndexedDbCachedProvider({
+                baseProvider,
+                dbName: 'test',
+                closeSignal: controller.signal,
+            });
+
+            await provider.clearCache();
+
+            await provider.elements({
+                elementIds: [element('a'), element('b'), element('c')],
+            });
+
+            expect(elementsSpy.mock.calls.map(call => call[0].elementIds)).toEqual([
+                [element('a'), element('b'), element('c')],
+            ] satisfies Array<ElementIri[]>);
+
+            await provider.elements({
+                elementIds: [element('d'), element('b'), element('c'), element('e')],
+            });
+
+            expect(elementsSpy.mock.calls.map(call => call[0].elementIds)).toEqual([
+                [element('a'), element('b'), element('c')],
+                [element('d'), element('e')],
+            ] satisfies Array<ElementIri[]>);
+        } finally {
+            controller.abort();
+        }
+    });
+
+    it('caches data for element/link/property types', async () => {
+        const baseProvider = new MockDataProvider();
+        const elementTypesSpy = vi.spyOn(baseProvider, 'elementTypes');
+        const linkTypesSpy = vi.spyOn(baseProvider, 'linkTypes');
+        const propertyTypesSpy = vi.spyOn(baseProvider, 'propertyTypes');
+
+        const controller = new AbortController();
+        try {
+            const provider = new IndexedDbCachedProvider({
+                baseProvider,
+                dbName: 'test',
+                closeSignal: controller.signal,
+            });
+
+            await provider.clearCache();
+
+            await provider.elementTypes({
+                classIds: [elementType('a'), elementType('b'), elementType('c')],
+            });
+
+            await provider.linkTypes({
+                linkTypeIds: [linkType('a'), linkType('b'), linkType('c')],
+            });
+
+            await provider.propertyTypes({
+                propertyIds: [propertyType('a'), propertyType('b'), propertyType('c')],
+            });
+
+            expect(elementTypesSpy.mock.calls.map(call => call[0].classIds)).toEqual([
+                [elementType('a'), elementType('b'), elementType('c')],
+            ] satisfies Array<ElementTypeIri[]>);
+
+            expect(linkTypesSpy.mock.calls.map(call => call[0].linkTypeIds)).toEqual([
+                [linkType('a'), linkType('b'), linkType('c')],
+            ] satisfies Array<LinkTypeIri[]>);
+
+            expect(propertyTypesSpy.mock.calls.map(call => call[0].propertyIds)).toEqual([
+                [propertyType('a'), propertyType('b'), propertyType('c')],
+            ] satisfies Array<PropertyTypeIri[]>);
+
+            await provider.elementTypes({
+                classIds: [elementType('d'), elementType('b'), elementType('c'), elementType('e')],
+            });
+
+            await provider.linkTypes({
+                linkTypeIds: [linkType('d'), linkType('b'), linkType('c'), linkType('e')],
+            });
+
+            await provider.propertyTypes({
+                propertyIds: [propertyType('d'), propertyType('b'), propertyType('c'), propertyType('e')],
+            });
+
+            expect(elementTypesSpy.mock.calls.map(call => call[0].classIds)).toEqual([
+                [elementType('a'), elementType('b'), elementType('c')],
+                [elementType('d'), elementType('e')],
+            ] satisfies Array<ElementTypeIri[]>);
+
+            expect(linkTypesSpy.mock.calls.map(call => call[0].linkTypeIds)).toEqual([
+                [linkType('a'), linkType('b'), linkType('c')],
+                [linkType('d'), linkType('e')],
+            ] satisfies Array<LinkTypeIri[]>);
+
+            expect(propertyTypesSpy.mock.calls.map(call => call[0].propertyIds)).toEqual([
+                [propertyType('a'), propertyType('b'), propertyType('c')],
+                [propertyType('d'), propertyType('e')],
+            ] satisfies Array<PropertyTypeIri[]>);
+        } finally {
+            controller.abort();
+        }
+    });
+
+    it('avoid caching missing data if disabled via option', async () => {
+        const baseProvider = new MockDataProvider();
+        const elementsSpy = vi.spyOn(baseProvider, 'elements');
+        const elementTypesSpy = vi.spyOn(baseProvider, 'elementTypes');
+        const linkTypesSpy = vi.spyOn(baseProvider, 'linkTypes');
+        const propertyTypesSpy = vi.spyOn(baseProvider, 'propertyTypes');
+
+        const controller = new AbortController();
+        try {
+            const provider = new IndexedDbCachedProvider({
+                baseProvider,
+                dbName: 'test',
+                closeSignal: controller.signal,
+            });
+
+            await provider.clearCache();
+
+            const requestData = async () => {
+                await provider.elements({
+                    elementIds: [element('a'), missing(element('b'))],
+                });
+    
+                await provider.elementTypes({
+                    classIds: [elementType('a'), missing(elementType('b'))],
+                });
+    
+                await provider.linkTypes({
+                    linkTypeIds: [linkType('a'), missing(linkType('b'))],
+                });
+    
+                await provider.propertyTypes({
+                    propertyIds: [propertyType('a'), missing(propertyType('b'))],
+                });
+            };
+
+            await requestData();
+            await requestData();
+
+            expect(elementsSpy.mock.calls.map(call => call[0].elementIds)).toEqual([
+                [element('a'), missing(element('b'))],
+                [missing(element('b'))],
+            ] satisfies Array<ElementIri[]>);
+
+            expect(elementTypesSpy.mock.calls.map(call => call[0].classIds)).toEqual([
+                [elementType('a'), missing(elementType('b'))],
+                [missing(elementType('b'))],
+            ] satisfies Array<ElementTypeIri[]>);
+
+            expect(linkTypesSpy.mock.calls.map(call => call[0].linkTypeIds)).toEqual([
+                [linkType('a'), missing(linkType('b'))],
+                [missing(linkType('b'))],
+            ] satisfies Array<LinkTypeIri[]>);
+
+            expect(propertyTypesSpy.mock.calls.map(call => call[0].propertyIds)).toEqual([
+                [propertyType('a'), missing(propertyType('b'))],
+                [missing(propertyType('b'))],
+            ] satisfies Array<PropertyTypeIri[]>);
+        } finally {
+            controller.abort();
+        }
+    });
+
+    it('caches data for links', async () => {
+        const baseProvider = new MockDataProvider();
+        const linksSpy = vi.spyOn(baseProvider, 'links');
+
+        const popLinksCalls = () => {
+            const calls = linksSpy.mock.calls.map(
+                ([params]) => ({targets: params.targetElements, paired: params.pairedElements})
+            );
+            linksSpy.mock.calls.length = 0;
+            return calls;
+        };
+        type LinkRequest = ReturnType<typeof popLinksCalls>;
+
+        const controller = new AbortController();
+        try {
+            const provider = new IndexedDbCachedProvider({
+                baseProvider,
+                dbName: 'test',
+                closeSignal: controller.signal,
+            });
+
+            await provider.clearCache();
+
+            await provider.links({
+                targetElements: [element('a'), element('b'), element('c'), element('d')],
+                pairedElements: [element('a'), element('b'), element('e')],
+            });
+
+            expect(popLinksCalls()).toEqual([
+                {
+                    targets: [element('a'), element('b'), element('c'), element('d')],
+                    paired: [element('a'), element('b'), element('e')]
+                },
+            ] satisfies LinkRequest);
+
+            await provider.links({
+                targetElements: [element('a'), element('b')],
+                pairedElements: [element('b')],
+            });
+
+            expect(popLinksCalls()).toEqual([] satisfies LinkRequest);
+
+            await provider.links({
+                targetElements: [element('c'), element('x')],
+                pairedElements: [element('a'), element('f')],
+            });
+
+            expect(popLinksCalls()).toEqual([
+                {
+                    targets: [element('c')],
+                    paired: [element('f')],
+                },
+                {
+                    targets: [element('x')],
+                    paired: [element('a'), element('f')],
+                },
+            ] satisfies LinkRequest);
+
+            await provider.links({
+                targetElements: [element('c')],
+                pairedElements: [element('a'), element('b')],
+            });
+
+            expect(popLinksCalls()).toEqual([] satisfies LinkRequest);
+        } finally {
+            controller.abort();
+        }
+    });
+
+    it('caches data for links (ascending)', async () => {
+        const baseProvider = new MockDataProvider();
+        const linksSpy = vi.spyOn(baseProvider, 'links');
+
+        const popLinksCalls = () => {
+            const calls = linksSpy.mock.calls.map(
+                ([params]) => ({targets: params.targetElements, paired: params.pairedElements})
+            );
+            linksSpy.mock.calls.length = 0;
+            return calls;
+        };
+        type LinkRequest = ReturnType<typeof popLinksCalls>;
+
+        const controller = new AbortController();
+        try {
+            const provider = new IndexedDbCachedProvider({
+                baseProvider,
+                dbName: 'test',
+                closeSignal: controller.signal,
+            });
+
+            await provider.clearCache();
+
+            await provider.links({
+                targetElements: [element('a')],
+                pairedElements: [element('a')],
+            });
+
+            expect(popLinksCalls()).toEqual([
+                {
+                    targets: [element('a')],
+                    paired: [element('a')],
+                },
+            ] satisfies LinkRequest);
+
+            await provider.links({
+                targetElements: [element('a'), element('b')],
+                pairedElements: [element('b')],
+            });
+
+            expect(popLinksCalls()).toEqual([
+                {
+                    targets: [element('a'), element('b')],
+                    paired: [element('b')],
+                },
+            ] satisfies LinkRequest);
+
+            await provider.links({
+                targetElements: [element('a'), element('b'), element('c')],
+                pairedElements: [element('c')],
+            });
+
+            expect(popLinksCalls()).toEqual([
+                {
+                    targets: [element('a'), element('b'), element('c')],
+                    paired: [element('c')],
+                },
+            ] satisfies LinkRequest);
+
+            await provider.links({
+                targetElements: [element('a'), element('b'), element('c'), element('d')],
+                pairedElements: [element('d')],
+            });
+
+            expect(popLinksCalls()).toEqual([
+                {
+                    targets: [element('a'), element('b'), element('c'), element('d')],
+                    paired: [element('d')],
+                },
+            ] satisfies LinkRequest);
+
+            await provider.links({
+                targetElements: [element('a'), element('b'), element('c'), element('d')],
+                pairedElements: [element('a'), element('b'), element('c'), element('d')],
+            });
+
+            expect(popLinksCalls()).toEqual([] satisfies LinkRequest);
+        } finally {
+            controller.abort();
+        }
+    });
+
+    it('uses cached data for reverse links as well', async () => {
+        const baseProvider = new MockDataProvider();
+        const linksSpy = vi.spyOn(baseProvider, 'links');
+
+        const popLinksCalls = () => {
+            const calls = linksSpy.mock.calls.map(
+                ([params]) => ({targets: params.targetElements, paired: params.pairedElements})
+            );
+            linksSpy.mock.calls.length = 0;
+            return calls;
+        };
+        type LinkRequest = ReturnType<typeof popLinksCalls>;
+
+        const controller = new AbortController();
+        try {
+            const provider = new IndexedDbCachedProvider({
+                baseProvider,
+                dbName: 'test',
+                closeSignal: controller.signal,
+            });
+
+            await provider.clearCache();
+
+            await provider.links({
+                targetElements: [element('a'), element('b'), element('c'), element('d')],
+                pairedElements: [element('a'), element('b'), element('e')],
+            });
+
+            expect(popLinksCalls()).toEqual([
+                {
+                    targets: [element('a'), element('b'), element('c'), element('d')],
+                    paired: [element('a'), element('b'), element('e')]
+                },
+            ] satisfies LinkRequest);
+
+            await provider.links({
+                targetElements: [element('e'), element('b')],
+                pairedElements: [element('b')],
+            });
+
+            expect(popLinksCalls()).toEqual([] satisfies LinkRequest);
+        } finally {
+            controller.abort();
+        }
+    });
+
+    it('returns all cached links matching the request', async () => {
+        const baseProvider = new MockDataProvider();
+
+        const controller = new AbortController();
+        try {
+            const provider = new IndexedDbCachedProvider({
+                baseProvider,
+                dbName: 'test',
+                closeSignal: controller.signal,
+            });
+
+            await provider.clearCache();
+
+            const links = await provider.links({
+                targetElements: [
+                    element('a'), element('bb'),
+                    element('aa'), element('b'),
+                    element('self-a'), element('self-aaa'),
+                    element('full-a'), element('full-b'),
+                ],
+                pairedElements: [
+                    element('a'), element('b'),
+                    element('aa'), element('bb'),
+                    element('self-a'), element('self-aa'),
+                    element('full-a'), element('full-b'),
+                ],
+            });
+
+            links.sort(compareLinks);
+
+            expect(links).toEqual([
+                {
+                    sourceId: 'element:a',
+                    targetId: 'element:aa',
+                    linkTypeId: 'link-type:prefix-of',
+                    properties: {},
+                },
+                {
+                    sourceId: 'element:b',
+                    targetId: 'element:bb',
+                    linkTypeId: 'link-type:prefix-of',
+                    properties: {},
+                },
+                {
+                    sourceId: 'element:full-a',
+                    targetId: 'element:full-b',
+                    linkTypeId: 'link-type:related',
+                    properties: {},
+                },
+                {
+                    sourceId: 'element:full-b',
+                    targetId: 'element:full-a',
+                    linkTypeId: 'link-type:related',
+                    properties: {},
+                },
+                {
+                    sourceId: 'element:self-a',
+                    targetId: 'element:self-a',
+                    linkTypeId: 'link-type:self',
+                    properties: {},
+                },
+                {
+                    sourceId: 'element:self-a',
+                    targetId: 'element:self-aa',
+                    linkTypeId: 'link-type:prefix-of',
+                    properties: {},
+                },
+                {
+                    sourceId: 'element:self-a',
+                    targetId: 'element:self-aaa',
+                    linkTypeId: 'link-type:prefix-of',
+                    properties: {},
+                },
+                {
+                    sourceId: 'element:self-aa',
+                    targetId: 'element:self-aaa',
+                    linkTypeId: 'link-type:prefix-of',
+                    properties: {},
+                },
+            ]);
+
+        } finally {
+            controller.abort();
+        }
+    });
+});
+
+function compareLinks(a: LinkModel, b: LinkModel): number {
+    let result = (
+        a.sourceId < b.sourceId ? -1 :
+        a.sourceId > b.sourceId ? 1 :
+        0
+    );
+    if (result !== 0) {
+        return result;
+    }
+    result = (
+        a.targetId < b.targetId ? -1 :
+        a.targetId > b.targetId ? 1 :
+        0
+    );
+    if (result !== 0) {
+        return result;
+    }
+    result = (
+        a.linkTypeId < b.linkTypeId ? -1 :
+        a.linkTypeId > b.linkTypeId ? 1 :
+        0
+    );
+    return result;
+}

--- a/test/mock/mockDataProvider.ts
+++ b/test/mock/mockDataProvider.ts
@@ -1,0 +1,212 @@
+import { HashSet } from '../../src/coreUtils/hashMap';
+import { EmptyDataProvider } from '../../src/data/decorated/emptyDataProvider';
+import {
+    ElementIri, ElementModel,
+    ElementTypeGraph,
+    ElementTypeIri, ElementTypeModel,
+    LinkModel,
+    LinkTypeIri, LinkTypeModel,
+    PropertyTypeIri, PropertyTypeModel,
+    hashLink, equalLinks,
+} from '../../src/data/model';
+
+export class MockDataProvider extends EmptyDataProvider {
+    knownElementTypes(params: {
+        signal?: AbortSignal | undefined;
+    }): Promise<ElementTypeGraph> {
+        const typeGraph: ElementTypeGraph = {
+            elementTypes: [
+                {
+                    id: elementType('root'),
+                    label: [],
+                },
+                {
+                    id: elementType('aa'),
+                    label: [],
+                },
+                {
+                    id: elementType('bb'),
+                    label: [],
+                },
+                {
+                    id: elementType('cc'),
+                    label: [],
+                }
+            ],
+            subtypeOf: [
+                [elementType('aa'), elementType('root')],
+                [elementType('bb'), elementType('root')],
+                [elementType('cc'), elementType('bb')],
+            ],
+        };
+        return Promise.resolve(typeGraph);
+    }
+
+    knownLinkTypes(params: {
+        signal?: AbortSignal | undefined;
+    }): Promise<LinkTypeModel[]> {
+        const linkTypes: LinkTypeModel[] = [
+            {
+                id: linkType('aa'),
+                label: [],
+            },
+            {
+                id: linkType('bb'),
+                label: [],
+            },
+            {
+                id: linkType('cc'),
+                label: [],
+            },
+        ];
+        return Promise.resolve(linkTypes);
+    }
+
+    elements(params: {
+        elementIds: readonly ElementIri[];
+        signal?: AbortSignal | undefined;
+    }): Promise<Map<ElementIri, ElementModel>> {
+        const result = new Map<ElementIri, ElementModel>();
+        for (const iri of params.elementIds) {
+            if (!iri.startsWith('element:')) {
+                continue;
+            }
+            result.set(iri, {
+                id: iri,
+                types: [],
+                label: [],
+                properties: {},
+            });
+        }
+        return Promise.resolve(result);
+    }
+
+    links(params: {
+        targetElements: ReadonlyArray<ElementIri>;
+        pairedElements: ReadonlyArray<ElementIri>;
+        linkTypeIds?: readonly LinkTypeIri[] | undefined;
+        signal?: AbortSignal | undefined;
+    }): Promise<LinkModel[]> {
+        const result = new HashSet<LinkModel>(hashLink, equalLinks);
+        for (const mainIri of params.targetElements) {
+            for (const pairedIri of params.pairedElements) {
+                if (mainIri === pairedIri) {
+                    if (mainIri.startsWith('element:self-')) {
+                        result.add({
+                            sourceId: mainIri,
+                            targetId: mainIri,
+                            linkTypeId: linkType('self'),
+                            properties: {},
+                        });
+                    }
+                } else {
+                    if (pairedIri.startsWith(mainIri)) {
+                        result.add({
+                            sourceId: mainIri,
+                            targetId: pairedIri,
+                            linkTypeId: linkType('prefix-of'),
+                            properties: {},
+                        });
+                    } else if (mainIri.startsWith(pairedIri)) {
+                        result.add({
+                            sourceId: pairedIri,
+                            targetId: mainIri,
+                            linkTypeId: linkType('prefix-of'),
+                            properties: {},
+                        });
+                    }
+
+                    if (
+                        mainIri.startsWith('element:full-') &&
+                        pairedIri.startsWith('element:full-')
+                    ) {
+                        result.add({
+                            sourceId: mainIri,
+                            targetId: pairedIri,
+                            linkTypeId: linkType('related'),
+                            properties: {},
+                        });
+                        result.add({
+                            sourceId: pairedIri,
+                            targetId: mainIri,
+                            linkTypeId: linkType('related'),
+                            properties: {},
+                        });
+                    }
+                }
+            }
+        }
+        return Promise.resolve(Array.from(result));
+    }
+
+    elementTypes(params: {
+        classIds: readonly ElementTypeIri[];
+        signal?: AbortSignal | undefined;
+    }): Promise<Map<ElementTypeIri, ElementTypeModel>> {
+        const result = new Map<ElementTypeIri, ElementTypeModel>();
+        for (const iri of params.classIds) {
+            if (!iri.startsWith('element-type:')) {
+                continue;
+            }
+            result.set(iri, {
+                id: iri,
+                label: [],
+            });
+        }
+        return Promise.resolve(result);
+    }
+
+    linkTypes(params: {
+        linkTypeIds: readonly LinkTypeIri[];
+        signal?: AbortSignal | undefined;
+    }): Promise<Map<LinkTypeIri, LinkTypeModel>> {
+        const result = new Map<LinkTypeIri, LinkTypeModel>();
+        for (const iri of params.linkTypeIds) {
+            if (!iri.startsWith('link-type:')) {
+                continue;
+            }
+            result.set(iri, {
+                id: iri,
+                label: [],
+            });
+        }
+        return Promise.resolve(result);
+    }
+
+    propertyTypes(params: {
+        propertyIds: readonly PropertyTypeIri[];
+        signal?: AbortSignal | undefined;
+    }): Promise<Map<PropertyTypeIri, PropertyTypeModel>> {
+        const result = new Map<PropertyTypeIri, PropertyTypeModel>();
+        for (const iri of params.propertyIds) {
+            if (!iri.startsWith('property-type:')) {
+                continue;
+            }
+            result.set(iri, {
+                id: iri,
+                label: [],
+            });
+        }
+        return Promise.resolve(result);
+    }
+}
+
+export function element(key: string): ElementIri {
+    return `element:${key}` as ElementIri;
+}
+
+export function elementType(key: string): ElementTypeIri {
+    return `element-type:${key}` as ElementTypeIri;
+}
+
+export function linkType(key: string): LinkTypeIri {
+    return `link-type:${key}` as LinkTypeIri;
+}
+
+export function propertyType(key: string): PropertyTypeIri {
+    return `property-type:${key}` as PropertyTypeIri;
+}
+
+export function missing<T extends string>(iri: T): T {
+    return `missing:${iri}` as T;
+}


### PR DESCRIPTION
* When querying links using `.links()` through the provider, each request will be merged into the IndexedDB-based cache in a way to only query unknown part of the request;
* Link caching can be disabled by setting `IndexedDdCachedProviderOptions.cacheLinks`
option to `false`;
* Replace `using` syntax to `try-finally` in `coreUtils/async.ts` to avoid syntax errors when running tests via Vitest;
* Add testing section to the README;