### PR TITLE
Auto-collapse `Navigator` when there is not enough space in the canvas viewport

### DIFF
--- a/src/diagram/canvasApi.ts
+++ b/src/diagram/canvasApi.ts
@@ -180,6 +180,11 @@ export interface CanvasEvents {
      */
     contextMenu: CanvasContextMenuEvent;
     /**
+     * Triggered on canvas viewport resize, tracked by a
+     * [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver).
+     */
+    resize: CanvasResizeEvent;
+    /**
      * Triggered on `isAnimatingGraph()` property change.
      */
     changeAnimatingGraph: PropertyChange<CanvasApi, boolean>;
@@ -280,6 +285,16 @@ export interface CanvasContextMenuEvent {
      * If `undefined` then the pointer event target is an empty canvas space.
      */
     readonly target: Cell | undefined;
+}
+
+/**
+ * Event data for canvas viewport resize event.
+ */
+export interface CanvasResizeEvent {
+    /**
+     * Event source (canvas).
+     */
+    readonly source: CanvasApi;
 }
 
 /**

--- a/src/diagram/paperArea.tsx
+++ b/src/diagram/paperArea.tsx
@@ -112,6 +112,8 @@ export class PaperArea extends React.Component<PaperAreaProps, State> implements
     private _pointerMode: CanvasPointerMode = 'panning';
     private readonly _zoomOptions: Required<ZoomOptions>;
 
+    private resizeObserver: ResizeObserver;
+
     readonly metrics: CanvasMetrics;
 
     constructor(props: PaperAreaProps, context: any) {
@@ -126,6 +128,7 @@ export class PaperArea extends React.Component<PaperAreaProps, State> implements
             paddingX: 0,
             paddingY: 0,
         };
+        this.resizeObserver = new ResizeObserver(this.onResize);
         this.metrics = new (class extends BasePaperMetrics {
             constructor(private readonly paperArea: PaperArea) {
                 super();
@@ -273,6 +276,8 @@ export class PaperArea extends React.Component<PaperAreaProps, State> implements
         this.area.addEventListener('drop', this.onDragDrop);
         this.area.addEventListener('scroll', this.onScroll, {passive: true});
         this.area.addEventListener('wheel', this.onWheel, {passive: false});
+
+        this.resizeObserver.observe(this.area);
     }
 
     componentDidUpdate(prevProps: PaperAreaProps, prevState: State) {
@@ -299,6 +304,7 @@ export class PaperArea extends React.Component<PaperAreaProps, State> implements
         this.area.removeEventListener('drop', this.onDragDrop);
         this.area.removeEventListener('scroll', this.onScroll);
         this.area.removeEventListener('wheel', this.onWheel);
+        this.resizeObserver.disconnect();
     }
 
     private *getAllWidgets(): IterableIterator<CanvasWidgetDescription> {
@@ -651,6 +657,10 @@ export class PaperArea extends React.Component<PaperAreaProps, State> implements
     private shouldStartZooming(e: MouseEvent | React.MouseEvent<any>) {
         return Boolean(e.ctrlKey) === this.zoomOptions.requireCtrl;
     }
+
+    private onResize: ResizeObserverCallback = () => {
+        this.source.trigger('resize', {source: this});
+    };
 
     centerTo(paperPosition?: Vector, options: CenterToOptions = {}): Promise<void> {
         const {width, height} = this.state;

--- a/styles/widgets/_navigator.scss
+++ b/styles/widgets/_navigator.scss
@@ -35,9 +35,12 @@
     opacity: 0.5;
     transition: opacity 0.3s;
 
-    &:hover {
-      // background: lightgray;
+    &:not(:disabled):hover {
       opacity: 1;
+    }
+
+    &:disabled {
+      opacity: 0.2;
     }
   }
   &--expanded &__toggle {


### PR DESCRIPTION
* Track canvas resizes via `ResizeObserver` and expose them with `CanvasEvents.resize` event;
* Add `autoCollapseFraction` option to `NavigatorProps` to automatically expand/collapse the navigator when canvas resizes and too much portion of the viewport is occupied by the widget;
* Disable expansion of `Navigator` when is won't fit at all in the expanded state.