### PR TITLE
Improve styles for `ToolbarLanguageSelector`

### DIFF
--- a/styles/widgets/_toolbarAction.scss
+++ b/styles/widgets/_toolbarAction.scss
@@ -65,7 +65,14 @@ $toolbarHeight: 30px;
     display: flex;
     align-items: center;
 
+    &:focus-within {
+      border-color: #66afe9;
+    }
+
     select {
+      background: none;
+      border: none;
+      outline: none;
       color: inherit;
       margin: 0;
       font: inherit;


### PR DESCRIPTION
* Remove extra borders and backgrounds from language selector;
* Display focus on language selector via outer selector border;