### PR TITLE
Allow to switch canvas pointer mode with `ZoomControl`

### DIFF
--- a/src/diagram/paperArea.tsx
+++ b/src/diagram/paperArea.tsx
@@ -476,8 +476,12 @@ export class PaperArea extends React.Component<PaperAreaProps, State> implements
     }
 
     private shouldStartPanning(e: React.PointerEvent) {
-        const modifierPressed = e.ctrlKey || e.shiftKey || e.altKey;
-        return e.pointerType === 'mouse' && !modifierPressed;
+        const requireShift = this._pointerMode === 'selection';
+        return (
+            e.pointerType === 'mouse' &&
+            e.shiftKey === requireShift &&
+            !(e.ctrlKey || e.altKey)
+        );
     }
 
     private shouldStartElementMove(e: React.PointerEvent) {
@@ -502,6 +506,7 @@ export class PaperArea extends React.Component<PaperAreaProps, State> implements
         } else if (typeof target === 'undefined') {
             e.preventDefault();
             if (panningOrigin) {
+                this.area.classList.add(`${CLASS_NAME}--panning`);
                 this.area.scrollLeft = panningOrigin.scrollLeft - pageOffsetX;
                 this.area.scrollTop = panningOrigin.scrollTop - pageOffsetY;
             }
@@ -622,6 +627,7 @@ export class PaperArea extends React.Component<PaperAreaProps, State> implements
         this.movingState = undefined;
 
         if (movingState) {
+            this.area.classList.remove(`${CLASS_NAME}--panning`);
             document.removeEventListener('pointermove', this.onPointerMove);
             document.removeEventListener('pointerup', this.onPointerUp);
             document.removeEventListener('pointercancel', this.onPointerCancel);

--- a/src/widgets/selection.tsx
+++ b/src/widgets/selection.tsx
@@ -115,7 +115,7 @@ export function Selection(props: SelectionProps) {
                 const requireShift = e.source.pointerMode !== 'selection';
                 const allowSelection = e.sourceEvent.shiftKey === requireShift;
                 if (
-                    (allowSelection || model.selection.length >= 1) &&
+                    (allowSelection || model.selection.length > 1) &&
                     e.target instanceof Element
                 ) {
                     e.sourceEvent.preventDefault();

--- a/src/widgets/zoomControl.tsx
+++ b/src/widgets/zoomControl.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import classnames from 'classnames';
 
+import { useObservedProperty } from '../coreUtils/hooks';
+
 import { useCanvas } from '../diagram/canvasApi';
 import { defineCanvasWidget } from '../diagram/canvasWidget';
 
@@ -28,6 +30,18 @@ export interface ZoomControlProps {
      * @default 0
      */
     dockOffsetY?: number;
+    /**
+     * Whether to display canvas pointer mode toggle.
+     *
+     * In `panning` mode moving the pointer with pressed main button pans the canvas
+     * area unless the Shift is held: in that case it selects the elements instead.
+     *
+     * In `selection` mode the actions are exchanged.
+     *
+     * @default false
+     * @see CanvasApi.pointerMode
+     */
+    showPointerModeToggle?: boolean;
 }
 
 const CLASS_NAME = 'reactodia-zoom-control';
@@ -38,8 +52,11 @@ const CLASS_NAME = 'reactodia-zoom-control';
  * @category Components
  */
 export function ZoomControl(props: ZoomControlProps) {
-    const {dock, dockOffsetX, dockOffsetY} = props;
+    const {dock, dockOffsetX, dockOffsetY, showPointerModeToggle} = props;
     const {canvas} = useCanvas();
+    const pointerMode = useObservedProperty(
+        canvas.events, 'changePointerMode', () => canvas.pointerMode
+    );
     return (
         <ViewportDock dock={dock}
             dockOffsetX={dockOffsetX}
@@ -69,6 +86,22 @@ export function ZoomControl(props: ZoomControlProps) {
                     title='Fit to Screen'
                     onClick={() => canvas.zoomToFit({animate: true})}>
                 </button>
+                {showPointerModeToggle ? (
+                    <button type='button'
+                        className={classnames(
+                            `${CLASS_NAME}__selection-mode-button`,
+                            'reactodia-btn reactodia-btn-default',
+                            pointerMode === 'selection' ? 'active' : undefined
+                        )}
+                        title={
+                            'Toggle selection mode:\n' +
+                            'Drag pointer to select, Shift + Pointer to pan the canvas'
+                        }
+                        onClick={() => canvas.setPointerMode(
+                            pointerMode === 'panning' ? 'selection' : 'panning'
+                        )}>
+                    </button>
+                ) : null}
             </div>
         </ViewportDock>
     );

--- a/styles/diagram/_paperArea.scss
+++ b/styles/diagram/_paperArea.scss
@@ -24,6 +24,10 @@
     }
   }
 
+  &--panning {
+    cursor: grabbing;
+  }
+
   &__widgets {
     position: absolute;
     left: 0;

--- a/styles/widgets/_zoomControl.scss
+++ b/styles/widgets/_zoomControl.scss
@@ -30,4 +30,10 @@
       @include icon("@images/zoom-to-fit.svg");
     }
   }
+
+  &__selection-mode-button {
+    &::before {
+      @include codicon("inspect");
+    }
+  }
 }


### PR DESCRIPTION
* Add `showPointerModeToggle` prop to `ZoomControl` to display pointer mode toggle;
* Fix canvas to consider `CanvasApi.pointerMode` when starting to pan its area;
* Fix `Selection` to avoid flicking selection when making a click on an already selected element;
* Change cursor to "grabbed" when panning the canvas;