### PR TITLE
Add support for ellipse-shaped elements and smooth-curved links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to the Reactodia will be documented in this document.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+#### 🚀 New Features
+- Support round (elliptical-shaped) elements:
+  * Allow element templates to set `shape: 'ellipse'` to correctly compute link geometry;
+  * Change `ElementTemplate` to be an object with additional element template options, allow to return both `ElementTemplate` and `ElementTemplateComponent` from `elementTemplateResolver`;
+  * Add built-in basic circle-shaped `RoundTemplate` with its `RoundEntity` template component;
+  * Add `RenderingState.getElementShape()` method to compute shape information (including bounds) for the element.
+- Support smooth-curved links:
+  * Allow link templates to set `spline: 'smooth'` to have rounded joints and overall shape via cubic Bézier curves.
+
+#### 💅 Polish
+- Export built-in element templates and its components separately for easier customization:
+  * Change `StandardTemplate` to a template object, expose its components as `StandardEntity` and `StandardEntityGroup`;
+  * Change `ClassicTemplate` to a template object, expose its component as `ClassicEntity`.
+
+#### 🔧 Maintenance
+- Replace `classnames` runtime dependency by `clsx`.
+- Update runtime dependencies: `n3`, `@vscode/codicons`.
+- Update dev-dependencies: Webpack + loaders, SASS, TypeScript, Vitest, ESLint.
 
 ## [0.28.1] - 2025-02-28
 #### 🐛 Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Export built-in element templates and its components separately for easier customization:
   * Change `StandardTemplate` to a template object, expose its components as `StandardEntity` and `StandardEntityGroup`;
   * Change `ClassicTemplate` to a template object, expose its component as `ClassicEntity`.
+- Improve default routing for self (feedback) links with a single user-defined variable to have a basic loop instead of a straight line.
 
 #### 🔧 Maintenance
 - Replace `classnames` runtime dependency by `clsx`.

--- a/examples/styleCustomization.tsx
+++ b/examples/styleCustomization.tsx
@@ -51,11 +51,11 @@ function StyleCustomizationExample() {
                 canvas={{
                     elementTemplateResolver: (types, element) => {
                         if (types.includes('http://www.w3.org/2002/07/owl#DatatypeProperty')) {
-                            return RoundTemplate;
+                            return RoundEntityTemplate;
                         }
                         return undefined;
                     },
-                    linkTemplateResolver: type => CUSTOM_LINK_TEMPLATE,
+                    linkTemplateResolver: type => DoubleArrowLinkTemplate,
                 }}
                 menu={<ExampleToolbarMenu />}
             />
@@ -63,9 +63,9 @@ function StyleCustomizationExample() {
     );
 }
 
-const RoundTemplate: Reactodia.ElementTemplate = {
-    component: RoundEntity,
+const RoundEntityTemplate: Reactodia.ElementTemplate = {
     shape: 'ellipse',
+    renderElement: props => <RoundEntity {...props} />,
 };
 
 function RoundEntity(props: Reactodia.TemplateProps) {
@@ -97,7 +97,7 @@ function RoundEntity(props: Reactodia.TemplateProps) {
     );
 }
 
-const CUSTOM_LINK_TEMPLATE: Reactodia.LinkTemplate = {
+const DoubleArrowLinkTemplate: Reactodia.LinkTemplate = {
     markerSource: {
         fill: '#4b4a67',
         stroke: '#4b4a67',
@@ -112,12 +112,12 @@ const CUSTOM_LINK_TEMPLATE: Reactodia.LinkTemplate = {
         width: 20,
         height: 12,
     },
-    splineType: 'smooth',
+    spline: 'smooth',
     renderLink: props => (
         <Reactodia.DefaultLinkPathTemplate {...props}
-            pathProps={{stroke: '#3c4260', strokeWidth: 2}}
+            pathProps={{stroke: '#747da8', strokeWidth: 2}}
             primaryLabelProps={{
-                textStyle: {fill: '#3c4260'},
+                textStyle: {fill: '#747da8'},
             }}
         />
     ),

--- a/examples/styleCustomization.tsx
+++ b/examples/styleCustomization.tsx
@@ -10,31 +10,6 @@ const COG_ICON = require('@vscode/codicons/src/icons/gear.svg');
 
 const TURTLE_DATA = require('./resources/orgOntology.ttl');
 
-const CUSTOM_LINK_TEMPLATE: Reactodia.LinkTemplate = {
-    markerSource: {
-        fill: '#4b4a67',
-        stroke: '#4b4a67',
-        d: 'M0,3a3,3 0 1,0 6,0a3,3 0 1,0 -6,0',
-        width: 6,
-        height: 6,
-    },
-    markerTarget: {
-        fill: '#4b4a67',
-        stroke: '#4b4a67',
-        d: 'm 20,5.88 -10.3,-5.95 0,5.6 -9.7,-5.6 0,11.82 9.7,-5.53 0,5.6 z',
-        width: 20,
-        height: 12,
-    },
-    renderLink: props => (
-        <Reactodia.DefaultLinkPathTemplate {...props}
-            pathProps={{stroke: '#3c4260', strokeWidth: 2}}
-            primaryLabelProps={{
-                textStyle: {fill: '#3c4260'},
-            }}
-        />
-    ),
-};
-
 const Layouts = Reactodia.defineLayoutWorker(() => new Worker('layout.worker.js'));
 
 function StyleCustomizationExample() {
@@ -66,7 +41,7 @@ function StyleCustomizationExample() {
                 } else if (types.indexOf('http://www.w3.org/2002/07/owl#ObjectProperty') !== -1) {
                     return {icon: COG_ICON};
                 } else if (types.indexOf('http://www.w3.org/2002/07/owl#DatatypeProperty') !== -1) {
-                    return {color: '#046380'};
+                    return {color: '#00b9f2'};
                 } else {
                     return undefined;
                 }
@@ -74,6 +49,12 @@ function StyleCustomizationExample() {
             onIriClick={({iri}) => window.open(iri)}>
             <Reactodia.DefaultWorkspace
                 canvas={{
+                    elementTemplateResolver: (types, element) => {
+                        if (types.includes('http://www.w3.org/2002/07/owl#DatatypeProperty')) {
+                            return RoundTemplate;
+                        }
+                        return undefined;
+                    },
                     linkTemplateResolver: type => CUSTOM_LINK_TEMPLATE,
                 }}
                 menu={<ExampleToolbarMenu />}
@@ -81,5 +62,65 @@ function StyleCustomizationExample() {
         </Reactodia.Workspace>
     );
 }
+
+const RoundTemplate: Reactodia.ElementTemplate = {
+    component: RoundEntity,
+    shape: 'ellipse',
+};
+
+function RoundEntity(props: Reactodia.TemplateProps) {
+    const {element} = props;
+    const {model, translation: t, getElementTypeStyle} = Reactodia.useWorkspace();
+
+    const data = element instanceof Reactodia.EntityElement ? element.data : undefined;
+    if (!data) {
+        return null;
+    }
+
+    const label = t.formatLabel(data.label, data.id, model.language);
+    const {color} = getElementTypeStyle(data.types);
+    return (
+        <div
+            style={{
+                width: 120,
+                height: 120,
+                background: 'var(--reactodia-element-background-color)',
+                border: '10px solid',
+                borderColor: color,
+                borderRadius: '50%',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+            }}>
+            {label}
+        </div>
+    );
+}
+
+const CUSTOM_LINK_TEMPLATE: Reactodia.LinkTemplate = {
+    markerSource: {
+        fill: '#4b4a67',
+        stroke: '#4b4a67',
+        d: 'M0,3a3,3 0 1,0 6,0a3,3 0 1,0 -6,0',
+        width: 6,
+        height: 6,
+    },
+    markerTarget: {
+        fill: '#4b4a67',
+        stroke: '#4b4a67',
+        d: 'm 20,5.88 -10.3,-5.95 0,5.6 -9.7,-5.6 0,11.82 9.7,-5.53 0,5.6 z',
+        width: 20,
+        height: 12,
+    },
+    splineType: 'smooth',
+    renderLink: props => (
+        <Reactodia.DefaultLinkPathTemplate {...props}
+            pathProps={{stroke: '#3c4260', strokeWidth: 2}}
+            primaryLabelProps={{
+                textStyle: {fill: '#3c4260'},
+            }}
+        />
+    ),
+};
 
 mountOnLoad(<StyleCustomizationExample />);

--- a/examples/styleCustomization.tsx
+++ b/examples/styleCustomization.tsx
@@ -50,8 +50,11 @@ function StyleCustomizationExample() {
             <Reactodia.DefaultWorkspace
                 canvas={{
                     elementTemplateResolver: (types, element) => {
-                        if (types.includes('http://www.w3.org/2002/07/owl#DatatypeProperty')) {
-                            return RoundEntityTemplate;
+                        if (
+                            types.includes('http://www.w3.org/2002/07/owl#DatatypeProperty') ||
+                            types.includes('http://www.w3.org/2002/07/owl#AnnotationProperty')
+                        ) {
+                            return Reactodia.RoundTemplate;
                         }
                         return undefined;
                     },
@@ -60,40 +63,6 @@ function StyleCustomizationExample() {
                 menu={<ExampleToolbarMenu />}
             />
         </Reactodia.Workspace>
-    );
-}
-
-const RoundEntityTemplate: Reactodia.ElementTemplate = {
-    shape: 'ellipse',
-    renderElement: props => <RoundEntity {...props} />,
-};
-
-function RoundEntity(props: Reactodia.TemplateProps) {
-    const {element} = props;
-    const {model, translation: t, getElementTypeStyle} = Reactodia.useWorkspace();
-
-    const data = element instanceof Reactodia.EntityElement ? element.data : undefined;
-    if (!data) {
-        return null;
-    }
-
-    const label = t.formatLabel(data.label, data.id, model.language);
-    const {color} = getElementTypeStyle(data.types);
-    return (
-        <div
-            style={{
-                width: 120,
-                height: 120,
-                background: 'var(--reactodia-element-background-color)',
-                border: '10px solid',
-                borderColor: color,
-                borderRadius: '50%',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-            }}>
-            {label}
-        </div>
     );
 }
 

--- a/src/diagram/customization.ts
+++ b/src/diagram/customization.ts
@@ -36,7 +36,8 @@ export type TypeStyleResolver = (types: ReadonlyArray<string>) => TypeStyle | un
 /**
  * Provides a custom component to render element on a diagram.
  */
-export type ElementTemplateResolver = (element: Element) => ElementTemplate | undefined;
+export type ElementTemplateResolver = (element: Element) =>
+    ElementTemplate | ElementTemplateComponent | undefined;
 /**
  * Provides a custom rendering on a diagram for links of specific type.
  */
@@ -59,7 +60,15 @@ export interface TypeStyle {
 /**
  * Custom component to render a single diagram element.
  */
-export type ElementTemplate = React.ComponentType<TemplateProps>;
+export type ElementTemplateComponent = React.ComponentType<TemplateProps>;
+
+export interface ElementTemplate {
+    readonly component: ElementTemplateComponent;
+    /**
+     * @default "rect"
+     */
+    readonly shape?: 'rect' | 'ellipse';
+}
 
 /**
  * Props for a custom {@link ElementTemplate} component.
@@ -101,6 +110,12 @@ export interface LinkTemplate {
      * SVG path marker style at the target of the link.
      */
     markerTarget?: LinkMarkerStyle;
+    /**
+     * SVG path spline type between source and target elements.
+     *
+     * @default "straight"
+     */
+    splineType?: 'straight' | 'smooth';
     /**
      * Renders the link component on SVG canvas.
      */

--- a/src/diagram/customization.ts
+++ b/src/diagram/customization.ts
@@ -34,7 +34,7 @@ export interface FormattedProperty {
  */
 export type TypeStyleResolver = (types: ReadonlyArray<string>) => TypeStyle | undefined;
 /**
- * Provides a custom component to render element on a diagram.
+ * Provides a custom template to render an element on the canvas.
  */
 export type ElementTemplateResolver = (element: Element) =>
     ElementTemplate | ElementTemplateComponent | undefined;
@@ -58,17 +58,30 @@ export interface TypeStyle {
 }
 
 /**
- * Custom component to render a single diagram element.
+ * Custom template to render a single diagram element.
  */
-export type ElementTemplateComponent = React.ComponentType<TemplateProps>;
-
 export interface ElementTemplate {
-    readonly component: ElementTemplateComponent;
     /**
+     * Assumed shape type for the rendered diagram element to
+     * correctly connect links and other geometry calculations.
+     *
      * @default "rect"
      */
     readonly shape?: 'rect' | 'ellipse';
+    /**
+     * Renders the element on the normal (non-SVG) canvas layer.
+     *
+     * **Note**: this should be a pure function, not a React component by itself.
+     */
+    readonly renderElement: (props: TemplateProps) => React.ReactNode;
 }
+
+/**
+ * Custom React component to render a single diagram element.
+ *
+ * @see {@link ElementTemplate}
+ */
+export type ElementTemplateComponent = React.ComponentType<TemplateProps>;
 
 /**
  * Props for a custom {@link ElementTemplate} component.
@@ -111,15 +124,19 @@ export interface LinkTemplate {
      */
     markerTarget?: LinkMarkerStyle;
     /**
-     * SVG path spline type between source and target elements.
+     * SVG path spline type between source and target elements:
+     *  - `straight`: a spline with straight line segments,
+     *  - `smooth`: a spline with cubic-bezier curve segments.
      *
      * @default "straight"
      */
-    splineType?: 'straight' | 'smooth';
+    spline?: 'straight' | 'smooth';
     /**
-     * Renders the link component on SVG canvas.
+     * Renders the link component on SVG canvas layer.
+     *
+     * **Note**: this should be a pure function, not a React component by itself.
      */
-    renderLink(props: LinkTemplateProps): React.ReactNode;
+    readonly renderLink: (props: LinkTemplateProps) => React.ReactNode;
 }
 
 /**

--- a/src/diagram/elementLayer.tsx
+++ b/src/diagram/elementLayer.tsx
@@ -4,7 +4,7 @@ import { findDOMNode, flushSync } from 'react-dom';
 import { EventObserver } from '../coreUtils/events';
 import { Debouncer } from '../coreUtils/scheduler';
 
-import { TemplateProps } from './customization';
+import { ElementTemplate, TemplateProps } from './customization';
 
 import { setElementExpanded } from './commands';
 import { Element, VoidElement } from './elements';
@@ -389,22 +389,22 @@ class OverlaidElement extends React.Component<OverlaidElementProps> {
 }
 
 class TemplatedElement extends React.Component<OverlaidElementProps> {
-    private cachedTemplateClass: React.ComponentType<TemplateProps> | undefined;
+    private cachedTemplate: ElementTemplate | undefined;
     private cachedTemplateProps: TemplateProps | undefined;
 
     render() {
         const {state, renderingState} = this.props;
         const {element, templateProps} = state;
-        const templateClass = renderingState.getElementTemplate(element);
-        this.cachedTemplateClass = templateClass;
+        const template = renderingState.getElementTemplate(element);
+        this.cachedTemplate = template;
         this.cachedTemplateProps = templateProps;
-        return React.createElement(templateClass, templateProps);
+        return React.createElement(template.component, templateProps);
     }
 
     shouldComponentUpdate(nextProps: OverlaidElementProps) {
-        const templateClass = nextProps.renderingState.getElementTemplate(nextProps.state.element);
+        const template = nextProps.renderingState.getElementTemplate(nextProps.state.element);
         return !(
-            this.cachedTemplateClass === templateClass &&
+            this.cachedTemplate?.component === template.component &&
             this.cachedTemplateProps === nextProps.state.templateProps
         );
     }

--- a/src/diagram/elementLayer.tsx
+++ b/src/diagram/elementLayer.tsx
@@ -398,13 +398,13 @@ class TemplatedElement extends React.Component<OverlaidElementProps> {
         const template = renderingState.getElementTemplate(element);
         this.cachedTemplate = template;
         this.cachedTemplateProps = templateProps;
-        return React.createElement(template.component, templateProps);
+        return template.renderElement(templateProps);
     }
 
     shouldComponentUpdate(nextProps: OverlaidElementProps) {
         const template = nextProps.renderingState.getElementTemplate(nextProps.state.element);
         return !(
-            this.cachedTemplate?.component === template.component &&
+            this.cachedTemplate === template &&
             this.cachedTemplateProps === nextProps.state.templateProps
         );
     }

--- a/src/diagram/geometry.ts
+++ b/src/diagram/geometry.ts
@@ -162,8 +162,17 @@ export function boundsOf(element: Element, sizeProvider: SizeProvider): Rect {
     };
 }
 
+/**
+ * Describes a basic 2D shape with a specific bounds (position and size).
+ */
 export interface ShapeGeometry {
+    /**
+     * Basic 2D shape type.
+     */
     readonly type: 'rect' | 'ellipse';
+    /**
+     * Shape bounds (position and size).
+     */
     readonly bounds: Rect;
 }
 

--- a/src/diagram/geometry.ts
+++ b/src/diagram/geometry.ts
@@ -281,6 +281,9 @@ export function computePolyline(
     let end: Vector | undefined;
     for (let i = vertices.length - 1; i >= 0; i--) {
         end = intersectRayFromShape(targetShape, vertices[i]);
+        if (end) {
+            break;
+        }
     }
     if (!end) {
         end = intersectRayFromShape(targetShape, Rect.center(sourceShape.bounds))

--- a/src/diagram/linkLayer.tsx
+++ b/src/diagram/linkLayer.tsx
@@ -297,7 +297,7 @@ function LinkView(props: LinkViewProps) {
     const targetShape = renderingState.getElementShape(target);
     const polyline = computePolyline(sourceShape, targetShape, vertices);
     const spline = Spline.create({
-        type: template.splineType ?? 'straight',
+        type: template.spline ?? 'straight',
         points: polyline,
         source: Rect.center(sourceShape.bounds),
         target: Rect.center(targetShape.bounds),

--- a/src/diagram/linkLayer.tsx
+++ b/src/diagram/linkLayer.tsx
@@ -8,8 +8,8 @@ import { restoreCapturedLinkGeometry } from './commands';
 import { LinkMarkerStyle, RoutedLink } from './customization';
 import { Element, Link, LinkVertex } from './elements';
 import {
-    Rect, Size, Vector, boundsOf, computePolyline, computePolylineLength,
-    getPointAlongPolyline, pathFromPolyline,
+    Rect, Size, Spline, Vector, computePolyline, computePolylineLength,
+    getPointAlongPolyline,
 } from './geometry';
 import { DiagramModel } from './model';
 import { MutableRenderingState, RenderingLayer } from './renderingState';
@@ -292,13 +292,16 @@ function LinkView(props: LinkViewProps) {
     const route = renderingState.getRouting(link.id);
     const verticesDefinedByUser = link.vertices;
     const vertices = route ? route.vertices : verticesDefinedByUser;
-    const polyline = computePolyline(
-        boundsOf(source, renderingState),
-        boundsOf(target, renderingState),
-        vertices
-    );
 
-    const path = pathFromPolyline(polyline);
+    const sourceShape = renderingState.getElementShape(source);
+    const targetShape = renderingState.getElementShape(target);
+    const polyline = computePolyline(sourceShape, targetShape, vertices);
+    const spline = Spline.create({
+        type: template.splineType ?? 'straight',
+        points: polyline,
+        source: Rect.center(sourceShape.bounds),
+        target: Rect.center(targetShape.bounds),
+    });
 
     const polylineLength = computePolylineLength(polyline);
     const getPathPosition = (offset: number) => {
@@ -314,7 +317,7 @@ function LinkView(props: LinkViewProps) {
         link,
         markerSource: `url(#${linkMarkerKey(typeIndex, true)})`,
         markerTarget: `url(#${linkMarkerKey(typeIndex, false)})`,
-        path,
+        path: spline.toPath(),
         getPathPosition,
         route,
     });

--- a/src/diagram/paperArea.tsx
+++ b/src/diagram/paperArea.tsx
@@ -15,7 +15,7 @@ import { extractCanvasWidget } from './canvasWidget';
 import { RestoreGeometry } from './commands';
 import { Element, Link, Cell, LinkVertex } from './elements';
 import {
-    Vector, Rect, boundsOf, computePolyline, findNearestSegmentIndex, getContentFittingBox,
+    Vector, Rect, computePolyline, findNearestSegmentIndex, getContentFittingBox,
 } from './geometry';
 import { DiagramModel } from './model';
 import { CommandBatch } from './history';
@@ -592,8 +592,8 @@ export class PaperArea extends React.Component<PaperAreaProps, State> implements
         const source = model.getElement(link.sourceId)!;
         const target = model.getElement(link.targetId)!;
         const polyline = computePolyline(
-            boundsOf(source, renderingState),
-            boundsOf(target, renderingState),
+            renderingState.getElementShape(source),
+            renderingState.getElementShape(target),
             vertices
         );
         const segmentIndex = findNearestSegmentIndex(polyline, location);

--- a/src/templates/classicTemplate.tsx
+++ b/src/templates/classicTemplate.tsx
@@ -4,12 +4,29 @@ import * as React from 'react';
 import { useKeyedSyncStore } from '../coreUtils/keyedObserver';
 
 import { ElementModel, PropertyTypeIri } from '../data/model';
-import { TemplateProps } from '../diagram/customization';
+import { ElementTemplate, TemplateProps } from '../diagram/customization';
 import { EntityElement } from '../editor/dataElements';
 import { subscribeElementTypes, subscribePropertyTypes } from '../editor/observedElement';
 import { WithFetchStatus } from '../editor/withFetchStatus';
 import { formatEntityTypeList } from '../widgets/utility/listElementView';
 import { useWorkspace } from '../workspace/workspaceContext';
+
+/**
+ * Element template component with classic "look and feel" which
+ * was used for elements before v0.8.0.
+ *
+ * Uses {@link ClassicEntity} component to render a single entity.
+ */
+export const ClassicTemplate: ElementTemplate = {
+    renderElement: props => <ClassicEntity {...props} />,
+};
+
+/**
+ * Props for {@link ClassicEntity} component.
+ *
+ * @see {@link ClassicEntity}
+ */
+export interface ClassicEntityProps extends TemplateProps {}
 
 const CLASS_NAME = 'reactodia-classic-template';
 
@@ -18,11 +35,13 @@ const CLASS_NAME = 'reactodia-classic-template';
  *
  * This classic "look and feel" was used for elements before v0.8.0
  *
- * The template does not support displaying entity groups.
+ * The template supports displaying only {@link EntityElement} elements,
+ * otherwise nothing will be rendered.
  *
  * @category Components
+ * @see {@link ClassicTemplate}
  */
-export function ClassicTemplate(props: TemplateProps) {
+export function ClassicEntity(props: ClassicEntityProps) {
     const {element, isExpanded} = props;
     const data = element instanceof EntityElement ? element.data : undefined;
 

--- a/src/templates/roundTemplate.tsx
+++ b/src/templates/roundTemplate.tsx
@@ -1,0 +1,104 @@
+import cx from 'clsx';
+import * as React from 'react';
+
+import { useKeyedSyncStore } from '../coreUtils/keyedObserver';
+
+import { ElementTemplate, TemplateProps } from '../diagram/customization';
+
+import { EntityElement } from '../editor/dataElements';
+import { subscribeElementTypes } from '../editor/observedElement';
+import { WithFetchStatus } from '../editor/withFetchStatus';
+
+import { formatEntityTypeList } from '../widgets/utility/listElementView';
+
+import { useWorkspace } from '../workspace/workspaceContext';
+
+/**
+ * Basic element template with an round (elliptical) shape to display
+ * an {@link EntityElement} on a canvas.
+ *
+ * Uses {@link RoundEntity} component to render a single entity.
+ */
+export const RoundTemplate: ElementTemplate = {
+    shape: 'ellipse',
+    renderElement: props => <RoundEntity {...props} />,
+};
+
+/**
+ * Props for {@link RoundEntity} component.
+ *
+ * @see {@link RoundEntity}
+ */
+export interface RoundEntityProps extends TemplateProps {
+    /**
+     * Additional CSS class for the component.
+     */
+    className?: string;
+    /**
+     * Additional CSS styles for the component.
+     */
+    style?: React.CSSProperties;
+    /**
+     * Whether to display entity types in the element.
+     *
+     * @default false
+     */
+    showTypes?: boolean;
+}
+
+const CLASS_NAME = 'reactodia-round-entity';
+
+/**
+ * Basic element template component with a round (elliptical) shape.
+ *
+ * The template supports displaying only {@link EntityElement} elements,
+ * otherwise nothing will be rendered.
+ *
+ * @category Components
+ * @see {@link RoundTemplate}
+ */
+export function RoundEntity(props: RoundEntityProps) {
+    const {element, className, style, showTypes} = props;
+    const workspace = useWorkspace();
+    const {model, translation: t, getElementTypeStyle} = workspace;
+
+    const data = element instanceof EntityElement ? element.data : undefined;
+    useKeyedSyncStore(subscribeElementTypes, data && showTypes ? data.types : [], model);
+
+    if (!data) {
+        return null;
+    }
+
+    const label = t.formatLabel(data.label, data.id, model.language);
+    const {color: baseColor} = getElementTypeStyle(data.types);
+    const rootStyle = {
+        '--reactodia-element-style-color': baseColor,
+    } as React.CSSProperties;
+
+    return (
+        <div className={cx(CLASS_NAME, className)}
+            style={style ? {...rootStyle, ...style} : rootStyle}>
+            <div className={`${CLASS_NAME}__types`}
+                title={showTypes ? formatEntityTypeList(data, workspace) : undefined}>
+                {showTypes ? data.types.map((typeIri, index) => {
+                    const type = model.getElementType(typeIri);
+                    const label = t.formatLabel(type?.data?.label, typeIri, model.language);
+                    return (
+                        <React.Fragment key={typeIri}>
+                            {index === 0 ? null : ', '}
+                            <WithFetchStatus type='elementType' target={typeIri}>
+                                <span>{label}</span>
+                            </WithFetchStatus>
+                        </React.Fragment>
+                    );
+                }) : null}
+            </div>
+            <WithFetchStatus type='element' target={data.id}>
+                <div className={`${CLASS_NAME}__label`}
+                    title={label}>
+                    {label}
+                </div>
+            </WithFetchStatus>
+        </div>
+    );
+}

--- a/src/templates/standardTemplate.tsx
+++ b/src/templates/standardTemplate.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import { useKeyedSyncStore } from '../coreUtils/keyedObserver';
 import type { Translation } from '../coreUtils/i18n';
 
-import type * as Rdf from '../data/rdf/rdfModel';
 import { ElementModel, PropertyTypeIri, isEncodedBlank } from '../data/model';
 import { PinnedProperties, TemplateProperties } from '../data/schema';
 
@@ -14,8 +13,7 @@ import { Element } from '../diagram/elements';
 import { HtmlSpinner } from '../diagram/spinner';
 
 import { AuthoringState } from '../editor/authoringState';
-import { DataDiagramModel } from '../editor/dataDiagramModel';
-import { EntityElement, EntityGroup, EntityGroupItem } from '../editor/dataElements';
+import { EntityElement, EntityGroup } from '../editor/dataElements';
 import { subscribeElementTypes, subscribePropertyTypes } from '../editor/observedElement';
 import { WithFetchStatus } from '../editor/withFetchStatus';
 
@@ -29,10 +27,20 @@ import { GroupPaginator } from './groupPaginator';
  * Default element template to display an {@link EntityElement} or
  * {@link EntityGroup} on a canvas.
  *
- * Uses {@link StandardEntity} component by default.
+ * Uses {@link StandardEntity} component to render a single entity and
+ * {@link StandardEntityGroup} component to render an entity group.
  */
 export const StandardTemplate: ElementTemplate = {
-    renderElement: props => <StandardEntity {...props} />,
+    renderElement: props => {
+        const {element} = props;
+        if (element instanceof EntityElement) {
+            return <StandardEntity {...props} />;
+        } else if (element instanceof EntityGroup) {
+            return <StandardEntityGroup {...props} />;
+        } else {
+            return null;
+        }
+    },
 };
 
 /**
@@ -40,76 +48,39 @@ export const StandardTemplate: ElementTemplate = {
  *
  * @see {@link StandardEntity}
  */
-export interface StandardEntityProps extends TemplateProps {
-    /**
-     * Default number items to show per page in element group.
-     *
-     * @default 6
-     */
-    groupPageSize?: number;
-    /**
-     * Available group page sizes to select from.
-     *
-     * @default [5, 10, 15, 20, 30]
-     */
-    groupPageSizes?: ReadonlyArray<number>;
-}
+export interface StandardEntityProps extends TemplateProps {}
+
+const CLASS_NAME = 'reactodia-standard-template';
 
 /**
- * Default element template component.
+ * Default single entity template component.
  *
- * The template supports displaying only {@link EntityElement} or {@link EntityGroup},
+ * The template supports displaying only {@link EntityElement},
  * otherwise nothing will be rendered.
  *
  * The template supports the following template state:
- *   - pinned properties;
- *   - group page index and size.
+ *   - {@link TemplateProperties.PinnedProperties}
  *
  * Entities can be edited or deleted using corresponding buttons
  * from the expanded state.
  *
  * @category Components
+ * @see {@link StandardTemplate}
  */
-export function StandardEntity(props: TemplateProps) {
-    const {element} = props;
-    if (element instanceof EntityElement) {
-        return (
-            <StandardEntityStandalone {...props}
-                data={element.data}
-                target={element}
-            />
-        );
-    } else if (element instanceof EntityGroup) {
-        return (
-            <StandardEntityGroup {...props}
-                items={element.items}
-                target={element}
-            />
-        );
-    } else {
-        return null;
-    }
-}
-
-interface StandardEntityBodyProps extends TemplateProps {
-    data: ElementModel;
-    target: Element;
-}
-
-const CLASS_NAME = 'reactodia-standard-template';
-const FOAF_NAME: PropertyTypeIri = 'http://xmlns.com/foaf/0.1/name';
-const DEFAULT_PAGE_SIZE = 10;
-const DEFAULT_PAGE_SIZES: ReadonlyArray<number> = [5, 10, 15, 20, 30];
-
-function StandardEntityStandalone(props: StandardEntityBodyProps) {
-    const {data, isExpanded, elementState, target} = props;
+export function StandardEntity(props: StandardEntityProps) {
+    const {element, isExpanded, elementState} = props;
     const workspace = useWorkspace();
     const {model, editor, translation: t, getElementTypeStyle} = workspace;
 
+    const data = element instanceof EntityElement ? element.data : undefined;
     useKeyedSyncStore(subscribeElementTypes, data ? data.types : [], model);
     const entityContext = useAuthoredEntity(data, isExpanded);
 
-    const label = formatEntityLabel(data, model, t);
+    if (!data) {
+        return null;
+    }
+
+    const label = t.formatLabel(data.label, data.id, model.language);
     const typesLabel = formatEntityTypes(data, workspace);
     const {color: baseColor, icon: iconUrl} = getElementTypeStyle(data.types);
     const rootStyle = {
@@ -118,7 +89,7 @@ function StandardEntityStandalone(props: StandardEntityBodyProps) {
 
     const pinnedProperties = findPinnedProperties() ?? {};
 
-    function renderTypes() {
+    function renderTypes(data: ElementModel) {
         if (data.types.length === 0) {
             return t.text('standard_template.default_type');
         }
@@ -144,7 +115,7 @@ function StandardEntityStandalone(props: StandardEntityBodyProps) {
         return pinned;
     }
 
-    function renderIri() {
+    function renderIri(data: ElementModel) {
         const finalIri = entityContext.editedIri === undefined ? data.id : entityContext.editedIri;
         return (
             <div>
@@ -169,7 +140,7 @@ function StandardEntityStandalone(props: StandardEntityBodyProps) {
         );
     }
 
-    function renderThumbnail() {
+    function renderThumbnail(data: ElementModel) {
         if (data.image) {
             return (
                 <div className={`${CLASS_NAME}__thumbnail`} aria-hidden='true'>
@@ -201,11 +172,11 @@ function StandardEntityStandalone(props: StandardEntityBodyProps) {
             <div className={`${CLASS_NAME}__main`}>
                 <div className={`${CLASS_NAME}__body`}>
                     <div className={`${CLASS_NAME}__body-horizontal`}>
-                        {renderThumbnail()}
+                        {renderThumbnail(data)}
                         <div className={`${CLASS_NAME}__body-content`}>
                             <div title={typesLabel} className={`${CLASS_NAME}__type`}>
                                 <div className={`${CLASS_NAME}__type-value`}>
-                                    {renderTypes()}
+                                    {renderTypes(data)}
                                 </div>
                             </div>
                             <WithFetchStatus type='element' target={data.id}>
@@ -230,13 +201,13 @@ function StandardEntityStandalone(props: StandardEntityBodyProps) {
                         </div>
                     ) : null}
                     <div className={`${CLASS_NAME}__dropdown-content`}>
-                        {renderIri()}
+                        {renderIri(data)}
                         <PropertyList data={data} />
                         {editor.inAuthoringMode ? <>
                             <hr className={`${CLASS_NAME}__hr`}
                                 data-reactodia-no-export='true'
                             />
-                            <Actions target={target}
+                            <Actions target={element}
                                 entityContext={entityContext}
                                 translation={t}
                             />
@@ -248,14 +219,47 @@ function StandardEntityStandalone(props: StandardEntityBodyProps) {
     );
 }
 
-interface StandardEntityGroupProps extends StandardEntityProps {
-    items: ReadonlyArray<EntityGroupItem>;
-    target: EntityGroup;
+/**
+ * Props for {@link StandardEntityGroup} component.
+ *
+ * @see {@link StandardEntityGroup}
+ */
+export interface StandardEntityGroupProps extends TemplateProps {
+    /**
+     * Default number items to show per page in element group.
+     *
+     * @default 6
+     */
+    groupPageSize?: number;
+    /**
+     * Available group page sizes to select from.
+     *
+     * @default [5, 10, 15, 20, 30]
+     */
+    groupPageSizes?: ReadonlyArray<number>;
 }
 
-function StandardEntityGroup(props: StandardEntityGroupProps) {
+const DEFAULT_PAGE_SIZE = 10;
+const DEFAULT_PAGE_SIZES: ReadonlyArray<number> = [5, 10, 15, 20, 30];
+
+/**
+ * Default entity group template component.
+ *
+ * The template supports displaying only {@link EntityGroup},
+ * otherwise nothing will be rendered.
+ *
+ * The template supports the following template state:
+ *   - {@link TemplateProperties.GroupPageIndex}
+ *   - {@link TemplateProperties.GroupPageSize}
+ *
+ * Entities can be ungroup from the element with a corresponding button.
+ *
+ * @category Components
+ * @see {@link StandardTemplate}
+ */
+export function StandardEntityGroup(props: StandardEntityGroupProps) {
     const {
-        items, target, elementState,
+        element, elementState,
         groupPageSize = DEFAULT_PAGE_SIZE,
         groupPageSizes = DEFAULT_PAGE_SIZES,
     } = props;
@@ -263,7 +267,12 @@ function StandardEntityGroup(props: StandardEntityGroupProps) {
     const workspace = useWorkspace();
     const {getElementStyle} = workspace;
 
-    const {color: groupColor} = getElementStyle(target);
+    if (!(element instanceof EntityGroup)) {
+        return null;
+    }
+    const items = element.items;
+
+    const {color: groupColor} = getElementStyle(element);
     const groupStyle = {
         '--reactodia-standard-group-color': groupColor,
     } as React.CSSProperties;
@@ -294,7 +303,7 @@ function StandardEntityGroup(props: StandardEntityGroupProps) {
                     key={item.data.id}
                     data={item.data}
                     isExpanded={false}
-                    target={target}
+                    target={element}
                     canvas={canvas}
                     workspace={workspace}
                 />
@@ -308,14 +317,14 @@ function StandardEntityGroup(props: StandardEntityGroupProps) {
             ))}
             <GroupPaginator pageIndex={pageIndex}
                 pageCount={pageCount}
-                onChangePage={page => target.setElementState({
-                    ...target.elementState,
+                onChangePage={page => element.setElementState({
+                    ...element.elementState,
                     [TemplateProperties.GroupPageIndex]: page,
                 })}
                 pageSize={pageSize}
                 pageSizes={groupPageSizes}
-                onChangePageSize={size => target.setElementState({
-                    ...target.elementState,
+                onChangePageSize={size => element.setElementState({
+                    ...element.elementState,
                     [TemplateProperties.GroupPageSize]: size,
                 })}
             />
@@ -336,7 +345,7 @@ function StandardEntityGroupItem(props: StandardEntityGroupItemProps) {
 
     useKeyedSyncStore(subscribeElementTypes, data ? data.types : [], model);
 
-    const label = formatEntityLabel(data, model, t);
+    const label = t.formatLabel(data.label, data.id, model.language);
     const iri = t.formatIri(data.id);
     const typesLabel = formatEntityTypes(data, workspace);
     const title = t.text('standard_template.group_item.title', {
@@ -396,27 +405,14 @@ function hasPinnedProperties(data: ElementModel, pinned: PinnedProperties): bool
     return false;
 }
 
-function formatEntityLabel(data: ElementModel, model: DataDiagramModel, t: Translation): string {
-    const foafName = Object.prototype.hasOwnProperty.call(data.properties, FOAF_NAME)
-        ? data.properties[FOAF_NAME] : undefined;
-    if (foafName) {
-        const literals = foafName.filter((v): v is Rdf.Literal => v.termType === 'Literal');
-        if (literals.length > 0) {
-            return t.formatLabel(literals, data.id, model.language);
-        }
-    }
-    return t.formatLabel(data.label, data.id, model.language);
-}
-
 function formatEntityTypes(
     data: ElementModel,
     workspace: WorkspaceContext
 ): string {
     const {translation: t} = workspace;
-    if (data.types.length === 0) {
-        return t.text('standard_template.default_type');
-    }
-    return formatEntityTypeList(data, workspace);
+    return data.types.length === 0
+        ? t.text('standard_template.default_type')
+        : formatEntityTypeList(data, workspace);
 }
 
 function getEntityAuthoredStatusClass(data: ElementModel, state: AuthoringState): string | undefined {

--- a/src/templates/standardTemplate.tsx
+++ b/src/templates/standardTemplate.tsx
@@ -9,7 +9,7 @@ import { ElementModel, PropertyTypeIri, isEncodedBlank } from '../data/model';
 import { PinnedProperties, TemplateProperties } from '../data/schema';
 
 import { CanvasApi, useCanvas } from '../diagram/canvasApi';
-import { TemplateProps } from '../diagram/customization';
+import { ElementTemplate, TemplateProps } from '../diagram/customization';
 import { Element } from '../diagram/elements';
 import { HtmlSpinner } from '../diagram/spinner';
 
@@ -26,11 +26,21 @@ import { type WorkspaceContext, useWorkspace } from '../workspace/workspaceConte
 import { GroupPaginator } from './groupPaginator';
 
 /**
- * Props for {@link StandardTemplate} component.
+ * Default element template to display an {@link EntityElement} or
+ * {@link EntityGroup} on a canvas.
  *
- * @see {@link StandardTemplate}
+ * Uses {@link StandardEntity} component by default.
  */
-export interface StandardTemplateProps extends TemplateProps {
+export const StandardTemplate: ElementTemplate = {
+    renderElement: props => <StandardEntity {...props} />,
+};
+
+/**
+ * Props for {@link StandardEntity} component.
+ *
+ * @see {@link StandardEntity}
+ */
+export interface StandardEntityProps extends TemplateProps {
     /**
      * Default number items to show per page in element group.
      *
@@ -48,7 +58,8 @@ export interface StandardTemplateProps extends TemplateProps {
 /**
  * Default element template component.
  *
- * The template supports displaying entity elements, including entity groups.
+ * The template supports displaying only {@link EntityElement} or {@link EntityGroup},
+ * otherwise nothing will be rendered.
  *
  * The template supports the following template state:
  *   - pinned properties;
@@ -59,18 +70,18 @@ export interface StandardTemplateProps extends TemplateProps {
  *
  * @category Components
  */
-export function StandardTemplate(props: TemplateProps) {
+export function StandardEntity(props: TemplateProps) {
     const {element} = props;
     if (element instanceof EntityElement) {
         return (
-            <StandardTemplateStandalone {...props}
+            <StandardEntityStandalone {...props}
                 data={element.data}
                 target={element}
             />
         );
     } else if (element instanceof EntityGroup) {
         return (
-            <StandardTemplateGroup {...props}
+            <StandardEntityGroup {...props}
                 items={element.items}
                 target={element}
             />
@@ -80,7 +91,7 @@ export function StandardTemplate(props: TemplateProps) {
     }
 }
 
-interface StandardTemplateBodyProps extends TemplateProps {
+interface StandardEntityBodyProps extends TemplateProps {
     data: ElementModel;
     target: Element;
 }
@@ -90,7 +101,7 @@ const FOAF_NAME: PropertyTypeIri = 'http://xmlns.com/foaf/0.1/name';
 const DEFAULT_PAGE_SIZE = 10;
 const DEFAULT_PAGE_SIZES: ReadonlyArray<number> = [5, 10, 15, 20, 30];
 
-function StandardTemplateStandalone(props: StandardTemplateBodyProps) {
+function StandardEntityStandalone(props: StandardEntityBodyProps) {
     const {data, isExpanded, elementState, target} = props;
     const workspace = useWorkspace();
     const {model, editor, translation: t, getElementTypeStyle} = workspace;
@@ -237,12 +248,12 @@ function StandardTemplateStandalone(props: StandardTemplateBodyProps) {
     );
 }
 
-interface StandardTemplateGroupProps extends StandardTemplateProps {
+interface StandardEntityGroupProps extends StandardEntityProps {
     items: ReadonlyArray<EntityGroupItem>;
     target: EntityGroup;
 }
 
-function StandardTemplateGroup(props: StandardTemplateGroupProps) {
+function StandardEntityGroup(props: StandardEntityGroupProps) {
     const {
         items, target, elementState,
         groupPageSize = DEFAULT_PAGE_SIZE,
@@ -279,7 +290,7 @@ function StandardTemplateGroup(props: StandardTemplateGroupProps) {
             style={groupStyle}
             role='list'>
             {pageItems.map(item => (
-                <StandardTemplateGroupItem {...props}
+                <StandardEntityGroupItem {...props}
                     key={item.data.id}
                     data={item.data}
                     isExpanded={false}
@@ -312,14 +323,14 @@ function StandardTemplateGroup(props: StandardTemplateGroupProps) {
     );
 }
 
-interface StandardTemplateGroupItemProps extends TemplateProps {
+interface StandardEntityGroupItemProps extends TemplateProps {
     data: ElementModel;
     target: EntityGroup;
     canvas: CanvasApi;
     workspace: WorkspaceContext;
 }
 
-function StandardTemplateGroupItem(props: StandardTemplateGroupItemProps) {
+function StandardEntityGroupItem(props: StandardEntityGroupItemProps) {
     const {data, target, canvas, workspace} = props;
     const {model, editor, translation: t, ungroupSome, getElementTypeStyle} = workspace;
 

--- a/src/widgets/canvas.tsx
+++ b/src/widgets/canvas.tsx
@@ -4,7 +4,7 @@ import { ColorSchemeApi } from '../coreUtils/colorScheme';
 
 import type { ZoomOptions } from '../diagram/canvasApi';
 import type {
-    LinkRouter, LinkTemplateResolver, ElementTemplate,
+    LinkRouter, LinkTemplateResolver, ElementTemplate, ElementTemplateComponent,
 } from '../diagram/customization';
 import { Element } from '../diagram/elements';
 import { PaperArea } from '../diagram/paperArea';
@@ -76,7 +76,8 @@ export interface CanvasProps {
  * Provides a custom component to render element on a diagram
  * based on the element itself and its type IRIs if the element is an entity.
  */
-export type TypedElementResolver = (types: readonly string[], element: Element) => ElementTemplate | undefined;
+export type TypedElementResolver = (types: readonly string[], element: Element) =>
+    ElementTemplate | ElementTemplateComponent | undefined;
 
 const CLASS_NAME = 'reactodia-canvas';
 

--- a/src/widgets/dialog.tsx
+++ b/src/widgets/dialog.tsx
@@ -192,8 +192,8 @@ export class Dialog extends React.Component<DialogProps, State> {
         const vertices = route ? route.vertices : verticesDefinedByUser;
 
         const polyline = computePolyline(
-            boundsOf(source, canvas.renderingState),
-            boundsOf(target, canvas.renderingState),
+            canvas.renderingState.getElementShape(source),
+            canvas.renderingState.getElementShape(target),
             vertices
         );
         const polylineLength = computePolylineLength(polyline);

--- a/src/widgets/haloLink.tsx
+++ b/src/widgets/haloLink.tsx
@@ -272,7 +272,7 @@ function computeLinkSpline(
     const points = computePolyline(sourceShape, targetShape, vertices);
     
     return Spline.create({
-        type: template?.splineType ?? 'straight',
+        type: template?.spline ?? 'straight',
         points,
         source: Rect.center(sourceShape.bounds),
         target: Rect.center(targetShape.bounds),

--- a/src/widgets/haloLink.tsx
+++ b/src/widgets/haloLink.tsx
@@ -7,8 +7,7 @@ import { CanvasApi, useCanvas } from '../diagram/canvasApi';
 import { defineCanvasWidget } from '../diagram/canvasWidget';
 import { Link } from '../diagram/elements';
 import {
-    Vector, boundsOf, computePolyline, computePolylineLength, getPointAlongPolyline,
-    pathFromPolyline,
+    Rect, Spline, Vector, computePolyline, computePolylineLength, getPointAlongPolyline,
 } from '../diagram/geometry';
 import type { DiagramModel, GraphStructure } from '../diagram/model';
 import { TransformedSvgCanvas } from '../diagram/paper';
@@ -99,7 +98,7 @@ interface State {
 }
 
 interface HaloLinkActionContext extends LinkActionContext {
-    readonly polyline: ReadonlyArray<Vector>;
+    readonly spline: Spline;
 }
 
 const CLASS_NAME = 'reactodia-halo-link';
@@ -126,16 +125,17 @@ class HaloLinkInner extends React.Component<HaloLinkInnerProps, State> {
             buttonMargin = DEFAULT_BUTTON_MARGIN,
         } = props;
 
-        const polyline = computeEffectiveLinkPolyline(target, model, canvas.renderingState);
-        if (!polyline) {
+        const spline = computeLinkSpline(target, model, canvas.renderingState);
+        if (!spline) {
             return null;
         }
-        const polylineLength = computePolylineLength(polyline);
+
+        const polylineLength = computePolylineLength(spline.geometry.points);
 
         const getPosition: LinkActionContext['getPosition'] = (side, index) => {
             const shift = (buttonSize + buttonMargin) * index;
             const point = getPointAlongPolyline(
-                polyline,
+                spline.geometry.points,
                 side === 'source' ? shift : (polylineLength - shift)
             );
             const {x, y} = canvas.metrics.paperToScrollablePaneCoords(point.x, point.y);
@@ -146,15 +146,16 @@ class HaloLinkInner extends React.Component<HaloLinkInnerProps, State> {
         };
 
         const getAngleInDegrees: LinkActionContext['getAngleInDegrees'] = side => {
-            const start = polyline[side === 'source' ? 1 : polyline.length - 1];
-            const end = polyline[side === 'source' ? 0 : polyline.length - 2];
+            const {points} = spline.geometry;
+            const start = points[side === 'source' ? 1 : points.length - 1];
+            const end = points[side === 'source' ? 0 : points.length - 2];
             const unit = Vector.normalize(Vector.subtract(end, start));
             return Math.atan2(unit.y, unit.x) * (180 / Math.PI);
         };
 
         return {
             link: target,
-            polyline,
+            spline,
             buttonSize,
             getPosition,
             getAngleInDegrees,
@@ -248,27 +249,34 @@ class HaloLinkInner extends React.Component<HaloLinkInnerProps, State> {
     }
 }
 
-function computeEffectiveLinkPolyline(
+function computeLinkSpline(
     link: Link,
     graph: GraphStructure,
     renderingState: RenderingState
-): ReadonlyArray<Vector> | undefined {
-    const sourceElement = graph.getElement(link.sourceId);
-    const targetElement = graph.getElement(link.targetId);
+): Spline | undefined {
+    const source = graph.getElement(link.sourceId);
+    const target = graph.getElement(link.targetId);
 
-    if (!(sourceElement && targetElement)) {
+    if (!(source && target)) {
         return undefined;
     }
+
+    const template = renderingState.getLinkTemplates().get(link.typeId);
 
     const route = renderingState.getRouting(link.id);
     const verticesDefinedByUser = link.vertices || [];
     const vertices = route ? route.vertices : verticesDefinedByUser;
 
-    return computePolyline(
-        boundsOf(sourceElement, renderingState),
-        boundsOf(targetElement, renderingState),
-        vertices
-    );
+    const sourceShape = renderingState.getElementShape(source);
+    const targetShape = renderingState.getElementShape(target);
+    const points = computePolyline(sourceShape, targetShape, vertices);
+    
+    return Spline.create({
+        type: template?.splineType ?? 'straight',
+        points,
+        source: Rect.center(sourceShape.bounds),
+        target: Rect.center(targetShape.bounds),
+    });
 }
 
 interface LinkHighlightProps {
@@ -278,7 +286,7 @@ interface LinkHighlightProps {
 }
 
 function LinkHighlight(props: LinkHighlightProps) {
-    const {actionContext: {link, polyline}, margin, canvas} = props;
+    const {actionContext: {link, spline}, margin, canvas} = props;
 
     const labelBoundsStore = useEventStore(canvas.renderingState.events, 'changeLinkLabelBounds');
     const labelBounds = useSyncStore(
@@ -305,8 +313,6 @@ function LinkHighlight(props: LinkHighlightProps) {
         height: y1 - y0 + margin * 2,
     };
 
-    const path = pathFromPolyline(polyline);
-
     return <>
         <div className={`${CLASS_NAME}__label-highlight`}
             style={labelHighlightStyle}
@@ -314,7 +320,7 @@ function LinkHighlight(props: LinkHighlightProps) {
         <TransformedSvgCanvas paperTransform={canvas.metrics.getTransform()}
             style={{overflow: 'visible', pointerEvents: 'none'}}>
             <path className={`${CLASS_NAME}__path-highlight`}
-                d={path}
+                d={spline.toPath()}
             />
         </TransformedSvgCanvas>
     </>;

--- a/src/widgets/navigator.tsx
+++ b/src/widgets/navigator.tsx
@@ -313,7 +313,8 @@ class NavigatorInner extends React.Component<NavigatorInnerProps, State> {
     private drawElements(ctx: CanvasRenderingContext2D, pt: PaperTransform, style: DrawStyle) {
         const {canvas, workspace: {model}} = this.props;
         for (const element of model.elements) {
-            const {x, y, width, height} = boundsOf(element, canvas.renderingState);
+            const {type, bounds: {x, y, width, height}} = canvas.renderingState.getElementShape(element);
+            ctx.beginPath();
             ctx.fillStyle = this.chooseElementColor(element, style);
 
             const {x: x1, y: y1} = canvasFromPaperCoords({x, y}, pt, this.transform);
@@ -322,7 +323,21 @@ class NavigatorInner extends React.Component<NavigatorInnerProps, State> {
                 y: y + height,
             }, pt, this.transform);
 
-            ctx.fillRect(x1, y1, x2 - x1, y2 - y1);
+            switch (type) {
+                case 'ellipse': {
+                    ctx.ellipse(
+                        (x1 + x2) / 2, (y1 + y2) / 2,
+                        (x2 - x1) / 2, (y2 - y1) / 2,
+                        0, Math.PI * 2, 0
+                    );
+                    break;
+                }
+                default: {
+                    ctx.rect(x1, y1, x2 - x1, y2 - y1);
+                    break;
+                }
+            }
+            ctx.fill();
         }
     }
 

--- a/src/widgets/visualAuthoring/authoredRelationOverlay.tsx
+++ b/src/widgets/visualAuthoring/authoredRelationOverlay.tsx
@@ -119,7 +119,7 @@ class LinkStateWidgetInner extends React.Component<AuthoredRelationOverlayInnerP
         const points = computePolyline(sourceShape, targetShape, vertices);
 
         return Spline.create({
-            type: template?.splineType ?? 'straight',
+            type: template?.spline ?? 'straight',
             points,
             source: Rect.center(sourceShape.bounds),
             target: Rect.center(targetShape.bounds),

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -141,12 +141,16 @@ export {
     SerializedLayoutLink, SerializedLayoutLinkGroup, SerializedLayoutLinkItem,
 } from './editor/serializedDiagram';
 
-export { ClassicTemplate } from './templates/classicTemplate';
+export { ClassicTemplate, ClassicEntity, ClassicEntityProps } from './templates/classicTemplate';
 export {
     DefaultLinkTemplate, DefaultLinkPathTemplate, DefaultLinkPathTemplateProps,
 } from './templates/defaultLinkTemplate';
 export { GroupPaginator, GroupPaginatorProps } from './templates/groupPaginator';
-export { StandardTemplate, StandardEntity, StandardEntityProps } from './templates/standardTemplate';
+export { RoundTemplate, RoundEntity, RoundEntityProps } from './templates/roundTemplate';
+export {
+    StandardTemplate, StandardEntity, StandardEntityProps,
+    StandardEntityGroup, StandardEntityGroupProps,
+} from './templates/standardTemplate';
 export { SemanticTypeStyles } from './templates/typeStyles';
 export { OntologyLinkTemplates, LINK_STYLE_SHOW_IRI } from './templates/linkStyles';
 

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -65,7 +65,11 @@ export {
     Link, LinkEvents, LinkProps, LinkTemplateState, LinkVertex,
     Cell, VoidElement, LinkTypeVisibility,
 } from './diagram/elements';
-export * from './diagram/geometry';
+export {
+    Rect, ShapeGeometry, Size, SizeProvider, Vector, boundsOf, calculateAveragePosition,
+    computePolyline, computePolylineLength, findElementAtPoint, findNearestSegmentIndex,
+    getContentFittingBox, getPointAlongPolyline, isPolylineEqual, pathFromPolyline,
+} from './diagram/geometry';
 export { CellsChangedEvent } from './diagram/graph';
 export * from './diagram/history';
 export {
@@ -142,7 +146,7 @@ export {
     DefaultLinkTemplate, DefaultLinkPathTemplate, DefaultLinkPathTemplateProps,
 } from './templates/defaultLinkTemplate';
 export { GroupPaginator, GroupPaginatorProps } from './templates/groupPaginator';
-export { StandardTemplate } from './templates/standardTemplate';
+export { StandardTemplate, StandardEntity, StandardEntityProps } from './templates/standardTemplate';
 export { SemanticTypeStyles } from './templates/typeStyles';
 export { OntologyLinkTemplates, LINK_STYLE_SHOW_IRI } from './templates/linkStyles';
 

--- a/src/workspace/workspace.tsx
+++ b/src/workspace/workspace.tsx
@@ -182,7 +182,7 @@ export class Workspace extends React.Component<WorkspaceProps> {
         model.setLanguage(defaultLanguage);
 
         const view = new SharedCanvasState({
-            defaultElementTemplate: StandardTemplate,
+            defaultElementTemplate: {component: StandardTemplate},
             defaultLinkTemplate: DefaultLinkTemplate,
             defaultLayout: defaultLayout ?? blockingDefaultLayout,
             renameLinkProvider,

--- a/src/workspace/workspace.tsx
+++ b/src/workspace/workspace.tsx
@@ -182,7 +182,7 @@ export class Workspace extends React.Component<WorkspaceProps> {
         model.setLanguage(defaultLanguage);
 
         const view = new SharedCanvasState({
-            defaultElementTemplate: {component: StandardTemplate},
+            defaultElementTemplate: StandardTemplate,
             defaultLinkTemplate: DefaultLinkTemplate,
             defaultLayout: defaultLayout ?? blockingDefaultLayout,
             renameLinkProvider,

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -52,4 +52,5 @@
 @forward "templates/classic";
 @forward "templates/defaultLink";
 @forward "templates/groupPaginator";
+@forward "templates/round";
 @forward "templates/standard";

--- a/styles/templates/_round.scss
+++ b/styles/templates/_round.scss
@@ -1,0 +1,35 @@
+@use "../theme/theme";
+
+.reactodia-round-entity {
+  width: 120px;
+  height: 120px;
+
+  background-color: var(--reactodia-element-background-color);
+  border: 4px solid var(--reactodia-element-style-color);
+  border-radius: 50%;
+  
+  display: grid;
+  grid-template-rows: 1fr 1fr 1fr;
+  align-items: center;
+  text-align: center;
+
+  &__types {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: 11px;
+    font-style: italic;
+    color: #999;
+    width: 65%;
+    justify-self: center;
+    align-self: end;
+  }
+
+  &__label {
+    font-size: 18px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    margin: 0 10px;
+  }
+}


### PR DESCRIPTION
- Support round (elliptical-shaped) elements:
  * Allow element templates to set `shape: 'ellipse'` to correctly compute link geometry;
  * Change `ElementTemplate` to be an object with additional element template options, allow to return both `ElementTemplate` and `ElementTemplateComponent` from `elementTemplateResolver`;
  * Add built-in basic circle-shaped `RoundTemplate` with its `RoundEntity` template component;
  * Add `RenderingState.getElementShape()` method to compute shape information (including bounds) for the element.
- Support smooth-curved links:
  * Allow link templates to set `spline: 'smooth'` to have rounded joints and overall shape via cubic Bézier curves.
- Export built-in element templates and its components separately for easier customization:
  * Change `StandardTemplate` to a template object, expose its components as `StandardEntity` and `StandardEntityGroup`;
  * Change `ClassicTemplate` to a template object, expose its component as `ClassicEntity`.
- Improve default routing for self (feedback) links with a single user-defined variable to have a basic loop instead of a straight line.