### PR TITLE
Replace explicit "commands" passing by `WorkspaceContext.getCommandBus()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   * Change `StandardTemplate` to a template object, expose its components as `StandardEntity` and `StandardEntityGroup`;
   * Change `ClassicTemplate` to a template object, expose its component as `ClassicEntity`.
 - Improve default routing for self (feedback) links with a single user-defined variable to have a basic loop instead of a straight line.
-- **[💥Breaking]** Replace explicit "commands" passing by common `WorkspaceContext.getExtensionCommands()`:
+- **[💥Breaking]** Replace explicit "commands" passing by common `WorkspaceContext.getCommandBus()`:
   * Remove all commands-like props from components, e.g. `commands`, `connectionMenuCommands`, `instancesSearchCommands`, `searchCommands`.
-  * Triggering a command or listening for one from outside the component should be done by acquiring a commands object using `getExtensionCommands()` with the following built-in extensions: `ConnectionsMenuExtension`, `InstancesSearchExtension`, `UnifiedSearchExtension`, `VisualAuthoringExtension`.
-  * **[🧪Experimental]** Custom extensions can be defined with `WorkspaceExtension.define()` (currently only provides a common events bus between components).
+  * Triggering a command or listening for one from outside the component should be done by acquiring a commands object using `getCommandBus()` with the following built-in command bus topics: `ConnectionsMenuTopic`, `InstancesSearchTopic`, `UnifiedSearchTopic`, `VisualAuthoringTopic`.
+  * **[🧪Experimental]** Custom command bus topics can be defined with `CommandBusTopic.define()`.
 
 #### 🔧 Maintenance
 - Replace `classnames` runtime dependency by `clsx`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   * Change `StandardTemplate` to a template object, expose its components as `StandardEntity` and `StandardEntityGroup`;
   * Change `ClassicTemplate` to a template object, expose its component as `ClassicEntity`.
 - Improve default routing for self (feedback) links with a single user-defined variable to have a basic loop instead of a straight line.
+- **[💥Breaking]** Replace explicit "commands" passing by common `WorkspaceContext.getExtensionCommands()`:
+  * Remove all commands-like props from components, e.g. `commands`, `connectionMenuCommands`, `instancesSearchCommands`, `searchCommands`.
+  * Triggering a command or listening for one from outside the component should be done by acquiring a commands object using `getExtensionCommands()` with the following built-in extensions: `ConnectionsMenuExtension`, `InstancesSearchExtension`, `UnifiedSearchExtension`, `VisualAuthoringExtension`.
+  * **[🧪Experimental]** Custom extensions can be defined with `WorkspaceExtension.define()` (currently only provides a common events bus between components).
 
 #### 🔧 Maintenance
 - Replace `classnames` runtime dependency by `clsx`.

--- a/examples/graphAuthoring.tsx
+++ b/examples/graphAuthoring.tsx
@@ -13,10 +13,6 @@ const Layouts = Reactodia.defineLayoutWorker(() => new Worker('layout.worker.js'
 function GraphAuthoringExample() {
     const {defaultLayout} = Reactodia.useWorker(Layouts);
 
-    const [searchCommands] = React.useState(() =>
-        new Reactodia.EventSource<Reactodia.UnifiedSearchCommands>
-    );
-
     const {onMount} = Reactodia.useLoadedWorkspace(async ({context, signal}) => {
         const {model, editor, performLayout} = context;
         editor.setAuthoringMode(true);
@@ -76,7 +72,6 @@ function GraphAuthoringExample() {
                     },
                 }}
                 menu={<ExampleToolbarMenu />}
-                searchCommands={searchCommands}
             />
         </Reactodia.Workspace>
     );

--- a/examples/rdfExplorer.tsx
+++ b/examples/rdfExplorer.tsx
@@ -12,13 +12,9 @@ const Layouts = Reactodia.defineLayoutWorker(() => new Worker('layout.worker.js'
 function RdfExample() {
     const {defaultLayout} = Reactodia.useWorker(Layouts);
 
-    const [searchCommands] = React.useState(() =>
-        new Reactodia.EventSource<Reactodia.UnifiedSearchCommands>
-    );
-
     const [turtleData, setTurtleData] = React.useState(TURTLE_DATA);
     const {onMount} = Reactodia.useLoadedWorkspace(async ({context, signal}) => {
-        const {model} = context;
+        const {model, getExtensionCommands} = context;
 
         const dataProvider = new Reactodia.RdfDataProvider();
         try {
@@ -36,7 +32,8 @@ function RdfExample() {
         });
 
         if (!diagram) {
-            searchCommands.trigger('focus', {sectionKey: 'elementTypes'});
+            getExtensionCommands(Reactodia.UnifiedSearchExtension)
+                .trigger('focus', {sectionKey: 'elementTypes'});
         }
     }, [turtleData]);
 
@@ -51,7 +48,6 @@ function RdfExample() {
                         <ExampleToolbarMenu />
                     </>
                 }
-                searchCommands={searchCommands}
                 languages={[
                     {code: 'de', label: 'Deutsch'},
                     {code: 'en', label: 'english'},

--- a/examples/rdfExplorer.tsx
+++ b/examples/rdfExplorer.tsx
@@ -14,7 +14,7 @@ function RdfExample() {
 
     const [turtleData, setTurtleData] = React.useState(TURTLE_DATA);
     const {onMount} = Reactodia.useLoadedWorkspace(async ({context, signal}) => {
-        const {model, getExtensionCommands} = context;
+        const {model, getCommandBus} = context;
 
         const dataProvider = new Reactodia.RdfDataProvider();
         try {
@@ -32,7 +32,7 @@ function RdfExample() {
         });
 
         if (!diagram) {
-            getExtensionCommands(Reactodia.UnifiedSearchExtension)
+            getCommandBus(Reactodia.UnifiedSearchTopic)
                 .trigger('focus', {sectionKey: 'elementTypes'});
         }
     }, [turtleData]);

--- a/examples/sparql.tsx
+++ b/examples/sparql.tsx
@@ -31,12 +31,8 @@ function SparqlExample() {
         setConnectionSettings(settings);
     };
 
-    const [searchCommands] = React.useState(() =>
-        new Reactodia.EventSource<Reactodia.UnifiedSearchCommands>
-    );
-
     const {onMount} = Reactodia.useLoadedWorkspace(async ({context, signal}) => {
-        const {model} = context;
+        const {model, getExtensionCommands} = context;
 
         if (connectionSettings) {
             const diagram = tryLoadLayoutFromLocalStorage();
@@ -53,7 +49,8 @@ function SparqlExample() {
             });
     
             if (!diagram) {
-                searchCommands.trigger('focus', {sectionKey: 'elementTypes'});
+                getExtensionCommands(Reactodia.UnifiedSearchExtension)
+                    .trigger('focus', {sectionKey: 'elementTypes'});
             }
         } else {
             showConnectionDialog(connectionSettings, applyConnectionSettings, context);
@@ -66,7 +63,6 @@ function SparqlExample() {
             onIriClick={({iri}) => window.open(iri)}>
             <Reactodia.DefaultWorkspace
                 menu={<ExampleToolbarMenu />}
-                searchCommands={searchCommands}
                 canvasWidgets={[
                     <Reactodia.Toolbar key='sparql-settings'
                         dock='sw'

--- a/examples/sparql.tsx
+++ b/examples/sparql.tsx
@@ -32,7 +32,7 @@ function SparqlExample() {
     };
 
     const {onMount} = Reactodia.useLoadedWorkspace(async ({context, signal}) => {
-        const {model, getExtensionCommands} = context;
+        const {model, getCommandBus} = context;
 
         if (connectionSettings) {
             const diagram = tryLoadLayoutFromLocalStorage();
@@ -49,7 +49,7 @@ function SparqlExample() {
             });
     
             if (!diagram) {
-                getExtensionCommands(Reactodia.UnifiedSearchExtension)
+                getCommandBus(Reactodia.UnifiedSearchTopic)
                     .trigger('focus', {sectionKey: 'elementTypes'});
             }
         } else {

--- a/examples/wikidata.tsx
+++ b/examples/wikidata.tsx
@@ -11,7 +11,7 @@ function WikidataExample() {
     const {defaultLayout} = Reactodia.useWorker(Layouts);
 
     const {onMount, getContext} = Reactodia.useLoadedWorkspace(async ({context, signal}) => {
-        const {model, getExtensionCommands} = context;
+        const {model, getCommandBus} = context;
 
         const sparqlProvider = new Reactodia.SparqlDataProvider(
             {
@@ -44,7 +44,7 @@ function WikidataExample() {
         });
 
         if (!diagram) {
-            getExtensionCommands(Reactodia.UnifiedSearchExtension)
+            getCommandBus(Reactodia.UnifiedSearchTopic)
                 .trigger('focus', {sectionKey: 'entities'});
         }
     }, []);

--- a/examples/wikidata.tsx
+++ b/examples/wikidata.tsx
@@ -10,12 +10,8 @@ const Layouts = Reactodia.defineLayoutWorker(() => new Worker('layout.worker.js'
 function WikidataExample() {
     const {defaultLayout} = Reactodia.useWorker(Layouts);
 
-    const [searchCommands] = React.useState(() =>
-        new Reactodia.EventSource<Reactodia.UnifiedSearchCommands>
-    );
-
     const {onMount, getContext} = Reactodia.useLoadedWorkspace(async ({context, signal}) => {
-        const {model} = context;
+        const {model, getExtensionCommands} = context;
 
         const sparqlProvider = new Reactodia.SparqlDataProvider(
             {
@@ -48,7 +44,8 @@ function WikidataExample() {
         });
 
         if (!diagram) {
-            searchCommands.trigger('focus', {sectionKey: 'entities'});
+            getExtensionCommands(Reactodia.UnifiedSearchExtension)
+                .trigger('focus', {sectionKey: 'entities'});
         }
     }, []);
 
@@ -84,7 +81,6 @@ function WikidataExample() {
                         </Reactodia.ToolbarAction>
                     </>
                 }
-                searchCommands={searchCommands}
                 connectionsMenu={{suggestProperties}}
                 languages={[
                     {code: 'de', label: 'Deutsch'},

--- a/src/editor/editorController.tsx
+++ b/src/editor/editorController.tsx
@@ -1,5 +1,5 @@
-import { Events, EventSource, EventObserver, EventTrigger, PropertyChange } from '../coreUtils/events';
-import { Translation, TranslatedText } from '../coreUtils/i18n';
+import { Events, EventSource, EventObserver, PropertyChange } from '../coreUtils/events';
+import { TranslatedText } from '../coreUtils/i18n';
 
 import { MetadataProvider } from '../data/metadataProvider';
 import { ValidationProvider } from '../data/validationProvider';
@@ -8,8 +8,6 @@ import { ElementModel, LinkModel, ElementIri, equalLinks } from '../data/model';
 import { Element, Link } from '../diagram/elements';
 import { Command } from '../diagram/history';
 import { GraphStructure } from '../diagram/model';
-
-import type { VisualAuthoringCommands } from '../widgets/visualAuthoring';
 
 import {
     AuthoringState, AuthoringEvent, TemporaryState,
@@ -24,7 +22,6 @@ import { ValidationState, changedElementsToValidate, validateElements } from './
 /** @hidden */
 export interface EditorProps {
     readonly model: DataDiagramModel;
-    readonly authoringCommands: Events<VisualAuthoringCommands> & EventTrigger<VisualAuthoringCommands>;
     readonly metadataProvider?: MetadataProvider;
     readonly validationProvider?: ValidationProvider;
 }
@@ -68,8 +65,6 @@ export class EditorController {
     readonly events: Events<EditorEvents> = this.source;
 
     private readonly model: DataDiagramModel;
-    private readonly _authoringCommands:
-        Events<VisualAuthoringCommands> & EventTrigger<VisualAuthoringCommands>;
 
     private _inAuthoringMode = false;
     private _metadataProvider: MetadataProvider | undefined;
@@ -82,9 +77,8 @@ export class EditorController {
 
     /** @hidden */
     constructor(props: EditorProps) {
-        const {model, authoringCommands, metadataProvider, validationProvider} = props;
+        const {model, metadataProvider, validationProvider} = props;
         this.model = model;
-        this._authoringCommands = authoringCommands;
         this._metadataProvider = metadataProvider;
         this._validationProvider = validationProvider;
 
@@ -109,13 +103,6 @@ export class EditorController {
     dispose(): void {
         this.listener.stopListening();
         this.cancellation.abort();
-    }
-
-    /**
-     * Event bus to connect {@link VisualAuthoring} to other components.
-     */
-    get authoringCommands(): Events<VisualAuthoringCommands> & EventTrigger<VisualAuthoringCommands> {
-        return this._authoringCommands;
     }
 
     /**

--- a/src/widgets/classTree/classTree.tsx
+++ b/src/widgets/classTree/classTree.tsx
@@ -23,8 +23,8 @@ import { ProgressBar, ProgressState } from '../utility/progressBar';
 import { SearchInput, SearchInputStore, useSearchInputStore } from '../utility/searchInput';
 
 import {
-    InstancesSearchExtension, VisualAuthoringExtension,
-} from '../../workspace/workspaceExtension';
+    InstancesSearchTopic, VisualAuthoringTopic,
+} from '../../workspace/commandBusTopic';
 import { WorkspaceContext, useWorkspace } from '../../workspace/workspaceContext';
 
 import { TreeNode } from './treeModel';
@@ -329,9 +329,9 @@ class ClassTreeInner extends React.Component<ClassTreeInnerProps, State> {
     };
 
     private onSelectNode = (node: TreeNode) => {
-        const {workspace: {getExtensionCommands}} = this.props;
+        const {workspace: {getCommandBus}} = this.props;
         this.setState({selectedNode: node}, () => {
-            getExtensionCommands(InstancesSearchExtension)
+            getCommandBus(InstancesSearchTopic)
                 .trigger('setCriteria', {
                     criteria: {elementType: node.iri},
                 });
@@ -404,7 +404,7 @@ class ClassTreeInner extends React.Component<ClassTreeInnerProps, State> {
     }
 
     private async createInstanceAt(elementType: ElementTypeIri, dropEvent?: CanvasDropEvent) {
-        const {workspace: {model, view, editor, getExtensionCommands: getCommandBus}} = this.props;
+        const {workspace: {model, view, editor, getCommandBus}} = this.props;
         const batch = model.history.startBatch();
 
         const signal = this.createElementCancellation.signal;
@@ -437,7 +437,7 @@ class ClassTreeInner extends React.Component<ClassTreeInnerProps, State> {
 
         batch.store();
         model.setSelection([element]);
-        getCommandBus(VisualAuthoringExtension)
+        getCommandBus(VisualAuthoringTopic)
             .trigger('editEntity', {target: element});
     }
 }

--- a/src/widgets/connectionsMenu.tsx
+++ b/src/widgets/connectionsMenu.tsx
@@ -25,7 +25,7 @@ import { SearchInput, SearchInputStore, useSearchInputStore } from '../widgets/u
 import type { InstancesSearchCommands } from '../widgets/instancesSearch';
 
 import { type WorkspaceContext, WorkspaceEventKey, useWorkspace } from '../workspace/workspaceContext';
-import { ConnectionsMenuExtension, InstancesSearchExtension } from '../workspace/workspaceExtension';
+import { ConnectionsMenuTopic, InstancesSearchTopic } from '../workspace/commandBusTopic';
 
 import { highlightSubstring } from './utility/listElementView';
 import { SearchResults, getAllPresentEntities } from './utility/searchResults';
@@ -143,7 +143,7 @@ export function ConnectionsMenu(props: ConnectionsMenuProps) {
 
     const lastSortMode = React.useRef<SortMode>('alphabet');
 
-    const commands = workspace.getExtensionCommands(ConnectionsMenuExtension);
+    const commands = workspace.getCommandBus(ConnectionsMenuTopic);
     React.useEffect(() => {
         const listener = new EventObserver();
         listener.listen(commands, 'findCapabilities', e => {
@@ -662,7 +662,7 @@ class ConnectionsMenuInner extends React.Component<ConnectionsMenuInnerProps, Me
                 return <LoadingSpinner />;
             }
 
-            const commands = workspace.getExtensionCommands(InstancesSearchExtension);
+            const commands = workspace.getCommandBus(InstancesSearchTopic);
             const event: InstancesSearchCommands['findCapabilities'] = {capabilities: []};
             commands.trigger('findCapabilities', event);
 
@@ -753,7 +753,7 @@ class ConnectionsMenuInner extends React.Component<ConnectionsMenuInnerProps, Me
     }
 
     private onMoveToFilter = (linkDataChunk: LinkDataChunk) => {
-        const {targetIris, workspace: {getExtensionCommands}} = this.props;
+        const {targetIris, workspace: {getCommandBus}} = this.props;
         const {linkType, direction} = linkDataChunk;
 
         const singleTargetIri = targetIris.length === 1 ? targetIris[0] : undefined;
@@ -761,7 +761,7 @@ class ConnectionsMenuInner extends React.Component<ConnectionsMenuInnerProps, Me
             return;
         }
         
-        const commands = getExtensionCommands(InstancesSearchExtension);
+        const commands = getCommandBus(InstancesSearchTopic);
         if (linkType.id === this.ALL_RELATED_ELEMENTS_LINK.id) {
             commands.trigger('setCriteria', {
                 criteria: {refElement: singleTargetIri},

--- a/src/widgets/connectionsMenu.tsx
+++ b/src/widgets/connectionsMenu.tsx
@@ -1,7 +1,7 @@
 import cx from 'clsx';
 import * as React from 'react';
 
-import { Events, EventObserver, EventTrigger } from '../coreUtils/events';
+import { EventObserver } from '../coreUtils/events';
 import { Debouncer } from '../coreUtils/scheduler';
 import { TranslatedText } from '../coreUtils/i18n';
 
@@ -25,6 +25,7 @@ import { SearchInput, SearchInputStore, useSearchInputStore } from '../widgets/u
 import type { InstancesSearchCommands } from '../widgets/instancesSearch';
 
 import { type WorkspaceContext, WorkspaceEventKey, useWorkspace } from '../workspace/workspaceContext';
+import { ConnectionsMenuExtension, InstancesSearchExtension } from '../workspace/workspaceExtension';
 
 import { highlightSubstring } from './utility/listElementView';
 import { SearchResults, getAllPresentEntities } from './utility/searchResults';
@@ -36,10 +37,6 @@ import { SearchResults, getAllPresentEntities } from './utility/searchResults';
  */
 export interface ConnectionsMenuProps {
     /**
-     * Event bus to listen commands for this component.
-     */
-    commands: Events<ConnectionsMenuCommands>;
-    /**
      * Whether to open (connected by) "All" link type by default.
      *
      * @default false
@@ -49,10 +46,6 @@ export interface ConnectionsMenuProps {
      * Smart link type suggestion provider when searching by the link type label.
      */
     suggestProperties?: PropertySuggestionHandler;
-    /**
-     * Event bus to send commands to {@link InstancesSearch} component.
-     */
-    instancesSearchCommands?: EventTrigger<InstancesSearchCommands>;
 }
 
 /**
@@ -61,6 +54,15 @@ export interface ConnectionsMenuProps {
  * @see {@link ConnectionsMenu}
  */
 export interface ConnectionsMenuCommands {
+    /**
+     * Triggered on a request to query implementations for its capabilities.
+     */
+    findCapabilities: {
+        /**
+         * Collects found connections menu capabilities.
+         */
+        readonly capabilities: Array<Record<string, never>>;
+    };
     /**
      * Can be triggered to open connections menu for the target elements.
      */
@@ -136,15 +138,17 @@ export interface PropertyScore {
  * @category Components
  */
 export function ConnectionsMenu(props: ConnectionsMenuProps) {
-    const {commands} = props;
-
     const workspace = useWorkspace();
     const {canvas} = useCanvas();
 
     const lastSortMode = React.useRef<SortMode>('alphabet');
 
+    const commands = workspace.getExtensionCommands(ConnectionsMenuExtension);
     React.useEffect(() => {
         const listener = new EventObserver();
+        listener.listen(commands, 'findCapabilities', e => {
+            e.capabilities.push({});
+        });
         listener.listen(commands, 'show', ({targets}) => {
             if (targets.length === 0) {
                 return;
@@ -629,7 +633,7 @@ class ConnectionsMenuInner extends React.Component<ConnectionsMenuInnerProps, Me
 
     private getBody() {
         const {
-            targetIris, instancesSearchCommands, connectionSearch, objectSearch, workspace,
+            targetIris, connectionSearch, objectSearch, workspace,
         } = this.props;
         const {
             panel, connectionSortMode, loadingState, objects, connections, connectionSuggestions,
@@ -657,6 +661,11 @@ class ConnectionsMenuInner extends React.Component<ConnectionsMenuInnerProps, Me
             ) {
                 return <LoadingSpinner />;
             }
+
+            const commands = workspace.getExtensionCommands(InstancesSearchExtension);
+            const event: InstancesSearchCommands['findCapabilities'] = {capabilities: []};
+            commands.trigger('findCapabilities', event);
+
             return (
                 <ConnectionsList
                     targetIris={targetIris}
@@ -668,7 +677,7 @@ class ConnectionsMenuInner extends React.Component<ConnectionsMenuInnerProps, Me
                     allRelatedLink={this.ALL_RELATED_ELEMENTS_LINK}
                     onExpandLink={this.onExpandLink}
                     onMoveToFilter={
-                        instancesSearchCommands && targetIris.length === 1
+                        event.capabilities.length > 0 && targetIris.length === 1
                             ? this.onMoveToFilter
                             : undefined
                     }
@@ -744,7 +753,7 @@ class ConnectionsMenuInner extends React.Component<ConnectionsMenuInnerProps, Me
     }
 
     private onMoveToFilter = (linkDataChunk: LinkDataChunk) => {
-        const {targetIris, instancesSearchCommands} = this.props;
+        const {targetIris, workspace: {getExtensionCommands}} = this.props;
         const {linkType, direction} = linkDataChunk;
 
         const singleTargetIri = targetIris.length === 1 ? targetIris[0] : undefined;
@@ -752,12 +761,13 @@ class ConnectionsMenuInner extends React.Component<ConnectionsMenuInnerProps, Me
             return;
         }
         
+        const commands = getExtensionCommands(InstancesSearchExtension);
         if (linkType.id === this.ALL_RELATED_ELEMENTS_LINK.id) {
-            instancesSearchCommands?.trigger('setCriteria', {
+            commands.trigger('setCriteria', {
                 criteria: {refElement: singleTargetIri},
             });
         } else {
-            instancesSearchCommands?.trigger('setCriteria', {
+            commands.trigger('setCriteria', {
                 criteria: {
                     refElement: singleTargetIri,
                     refElementLink: linkType.id,

--- a/src/widgets/halo.tsx
+++ b/src/widgets/halo.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { AnyListener, EventObserver, EventTrigger } from '../coreUtils/events';
+import { AnyListener, EventObserver } from '../coreUtils/events';
 import { useObservedProperty } from '../coreUtils/hooks';
 
 import { CanvasApi, useCanvas } from '../diagram/canvasApi';
@@ -8,8 +8,6 @@ import { defineCanvasWidget } from '../diagram/canvasWidget';
 import { Element, ElementEvents } from '../diagram/elements';
 import { boundsOf } from '../diagram/geometry';
 
-import type { ConnectionsMenuCommands } from './connectionsMenu';
-import type { InstancesSearchCommands } from './instancesSearch';
 import {
     SelectionActionRemove, SelectionActionExpand, SelectionActionAnchor,
     SelectionActionConnections, SelectionActionAddToFilter, SelectionActionGroup,
@@ -29,14 +27,6 @@ export interface HaloProps {
      */
     margin?: number;
     /**
-     * Event bus to send commands to {@link ConnectionMenu} component.
-     */
-    connectionsMenuCommands?: EventTrigger<ConnectionsMenuCommands>;
-    /**
-     * Event bus to send commands to {@link InstancesSearch} component.
-     */
-    instancesSearchCommands?: EventTrigger<InstancesSearchCommands>;
-    /**
      * {@link SelectionAction} items representing available actions on the selected element.
      *
      * **Default**:
@@ -46,12 +36,8 @@ export interface HaloProps {
      *   <SelectionActionRemove dock='ne' />
      *   <SelectionActionExpand dock='s' />
      *   <SelectionActionAnchor dock='w' />
-     *   <SelectionActionConnections dock='e'
-     *       commands={connectionsMenuCommands}
-     *   />
-     *   <SelectionActionAddToFilter dock='se'
-     *       commands={instancesSearchCommands}
-     *   />
+     *   <SelectionActionConnections dock='e' />
+     *   <SelectionActionAddToFilter dock='se' />
      *   <SelectionActionEstablishLink dock='sw' />
      * </>
      * ```
@@ -143,8 +129,6 @@ class HaloInner extends React.Component<HaloInnerProps> {
             target,
             canvas,
             margin = 5,
-            connectionsMenuCommands,
-            instancesSearchCommands,
             children,
         } = this.props;
 
@@ -168,12 +152,8 @@ class HaloInner extends React.Component<HaloInnerProps> {
                     <SelectionActionRemove dock='ne' />
                     <SelectionActionExpand dock='s' />
                     <SelectionActionAnchor dock='w' />
-                    <SelectionActionConnections dock='e'
-                        commands={connectionsMenuCommands}
-                    />
-                    <SelectionActionAddToFilter dock='se'
-                        commands={instancesSearchCommands}
-                    />
+                    <SelectionActionConnections dock='e' />
+                    <SelectionActionAddToFilter dock='se' />
                     <SelectionActionEstablishLink dock='sw' />
                 </>}
             </div>

--- a/src/widgets/instancesSearch.tsx
+++ b/src/widgets/instancesSearch.tsx
@@ -19,7 +19,7 @@ import {
 import { EntityElement, EntityGroup, iterateEntitiesOf } from '../editor/dataElements';
 
 import { WorkspaceContext, WorkspaceEventKey, useWorkspace } from '../workspace/workspaceContext';
-import { InstancesSearchExtension } from '../workspace/workspaceExtension';
+import { InstancesSearchTopic } from '../workspace/commandBusTopic';
 
 import { InlineEntity } from './utility/inlineEntity';
 import { NoSearchResults } from './utility/noSearchResults';
@@ -210,7 +210,7 @@ class InstancesSearchInner extends React.Component<InstancesSearchInnerProps, St
             );
         });
 
-        const commands = workspace.getExtensionCommands(InstancesSearchExtension);
+        const commands = workspace.getCommandBus(InstancesSearchTopic);
         this.listener.listen(commands, 'findCapabilities', e => {
             e.capabilities.push({});
         });

--- a/src/widgets/linkAction.tsx
+++ b/src/widgets/linkAction.tsx
@@ -17,6 +17,7 @@ import { AuthoringState } from '../editor/authoringState';
 import { EntityElement, RelationLink } from '../editor/dataElements';
 import { EditorController } from '../editor/editorController';
 
+import { VisualAuthoringExtension } from '../workspace/workspaceExtension';
 import { useWorkspace } from '../workspace/workspaceContext';
 
 /**
@@ -177,7 +178,7 @@ export interface LinkActionEditProps extends LinkActionStyleProps {}
 export function LinkActionEdit(props: LinkActionEditProps) {
     const {className, title, ...otherProps} = props;
     const {link} = useLinkActionContext();
-    const {model, editor, translation: t} = useWorkspace();
+    const {model, editor, translation: t, getExtensionCommands} = useWorkspace();
 
     const inAuthoringMode = useObservedProperty(
         editor.events, 'changeMode', () => editor.inAuthoringMode
@@ -216,7 +217,10 @@ export function LinkActionEdit(props: LinkActionEditProps) {
                     : t.text('link_action.edit_relation.title_disabled')
             )}
             disabled={!canModify.canChangeType}
-            onSelect={() => editor.authoringCommands.trigger('editRelation', {target: link})}
+            onSelect={() =>
+                getExtensionCommands(VisualAuthoringExtension)
+                    .trigger('editRelation', {target: link})
+            }
         />
     );
 }
@@ -352,7 +356,7 @@ export function LinkActionMoveEndpoint(props: LinkActionMoveEndpointProps) {
     const {dockSide, className, title, ...otherProps} = props;
     const {link, buttonSize, getAngleInDegrees} = useLinkActionContext();
     const {canvas} = useCanvas();
-    const {editor, translation: t} = useWorkspace();
+    const {editor, translation: t, getExtensionCommands} = useWorkspace();
 
     const inAuthoringMode = useObservedProperty(
         editor.events, 'changeMode', () => editor.inAuthoringMode
@@ -387,13 +391,14 @@ export function LinkActionMoveEndpoint(props: LinkActionMoveEndpointProps) {
             disabled={linkIsDeleted}
             onMouseDown={e => {
                 const point = canvas.metrics.pageToPaperCoords(e.pageX, e.pageY);
-                editor.authoringCommands.trigger('startDragEdit', {
-                    operation: {
-                        mode: dockSide === 'source' ? 'moveSource' : 'moveTarget',
-                        link,
-                        point,
-                    }
-                });
+                getExtensionCommands(VisualAuthoringExtension)
+                    .trigger('startDragEdit', {
+                        operation: {
+                            mode: dockSide === 'source' ? 'moveSource' : 'moveTarget',
+                            link,
+                            point,
+                        }
+                    });
             }}>
             <svg width={buttonSize} height={buttonSize}
                 style={{transform: `rotate(${angle}deg)`}}>
@@ -429,7 +434,7 @@ export function LinkActionRename(props: LinkActionRenameProps) {
     const {className, title} = props;
     const {link} = useLinkActionContext();
     const {canvas} = useCanvas();
-    const {view: {renameLinkProvider}, editor, translation: t} = useWorkspace();
+    const {view: {renameLinkProvider}, translation: t, getExtensionCommands} = useWorkspace();
 
     const labelBoundsStore = useEventStore(canvas.renderingState.events, 'changeLinkLabelBounds');
     const labelBounds = useSyncStore(
@@ -454,7 +459,10 @@ export function LinkActionRename(props: LinkActionRenameProps) {
         <button className={cx(className, `${CLASS_NAME}__rename`)}
             style={style}
             title={title ?? t.text('link_action.rename_link.title')}
-            onClick={() => editor.authoringCommands.trigger('renameLink', {target: link})}
+            onClick={() =>
+                getExtensionCommands(VisualAuthoringExtension)
+                    .trigger('renameLink', {target: link})
+            }
         />
     );
 }

--- a/src/widgets/linkAction.tsx
+++ b/src/widgets/linkAction.tsx
@@ -17,7 +17,7 @@ import { AuthoringState } from '../editor/authoringState';
 import { EntityElement, RelationLink } from '../editor/dataElements';
 import { EditorController } from '../editor/editorController';
 
-import { VisualAuthoringExtension } from '../workspace/workspaceExtension';
+import { VisualAuthoringTopic } from '../workspace/commandBusTopic';
 import { useWorkspace } from '../workspace/workspaceContext';
 
 /**
@@ -178,7 +178,7 @@ export interface LinkActionEditProps extends LinkActionStyleProps {}
 export function LinkActionEdit(props: LinkActionEditProps) {
     const {className, title, ...otherProps} = props;
     const {link} = useLinkActionContext();
-    const {model, editor, translation: t, getExtensionCommands} = useWorkspace();
+    const {model, editor, translation: t, getCommandBus} = useWorkspace();
 
     const inAuthoringMode = useObservedProperty(
         editor.events, 'changeMode', () => editor.inAuthoringMode
@@ -218,7 +218,7 @@ export function LinkActionEdit(props: LinkActionEditProps) {
             )}
             disabled={!canModify.canChangeType}
             onSelect={() =>
-                getExtensionCommands(VisualAuthoringExtension)
+                getCommandBus(VisualAuthoringTopic)
                     .trigger('editRelation', {target: link})
             }
         />
@@ -356,7 +356,7 @@ export function LinkActionMoveEndpoint(props: LinkActionMoveEndpointProps) {
     const {dockSide, className, title, ...otherProps} = props;
     const {link, buttonSize, getAngleInDegrees} = useLinkActionContext();
     const {canvas} = useCanvas();
-    const {editor, translation: t, getExtensionCommands} = useWorkspace();
+    const {editor, translation: t, getCommandBus} = useWorkspace();
 
     const inAuthoringMode = useObservedProperty(
         editor.events, 'changeMode', () => editor.inAuthoringMode
@@ -391,7 +391,7 @@ export function LinkActionMoveEndpoint(props: LinkActionMoveEndpointProps) {
             disabled={linkIsDeleted}
             onMouseDown={e => {
                 const point = canvas.metrics.pageToPaperCoords(e.pageX, e.pageY);
-                getExtensionCommands(VisualAuthoringExtension)
+                getCommandBus(VisualAuthoringTopic)
                     .trigger('startDragEdit', {
                         operation: {
                             mode: dockSide === 'source' ? 'moveSource' : 'moveTarget',
@@ -434,7 +434,7 @@ export function LinkActionRename(props: LinkActionRenameProps) {
     const {className, title} = props;
     const {link} = useLinkActionContext();
     const {canvas} = useCanvas();
-    const {view: {renameLinkProvider}, translation: t, getExtensionCommands} = useWorkspace();
+    const {view: {renameLinkProvider}, translation: t, getCommandBus} = useWorkspace();
 
     const labelBoundsStore = useEventStore(canvas.renderingState.events, 'changeLinkLabelBounds');
     const labelBounds = useSyncStore(
@@ -460,7 +460,7 @@ export function LinkActionRename(props: LinkActionRenameProps) {
             style={style}
             title={title ?? t.text('link_action.rename_link.title')}
             onClick={() =>
-                getExtensionCommands(VisualAuthoringExtension)
+                getCommandBus(VisualAuthoringTopic)
                     .trigger('renameLink', {target: link})
             }
         />

--- a/src/widgets/linksToolbox.tsx
+++ b/src/widgets/linksToolbox.tsx
@@ -12,7 +12,7 @@ import { Element, LinkTypeVisibility } from '../diagram/elements';
 import { LinkType, iterateEntitiesOf } from '../editor/dataElements';
 import { WithFetchStatus } from '../editor/withFetchStatus';
 
-import { InstancesSearchExtension } from '../workspace/workspaceExtension';
+import { InstancesSearchTopic } from '../workspace/commandBusTopic';
 import { WorkspaceContext, useWorkspace } from '../workspace/workspaceContext';
 
 import { InlineEntity } from './utility/inlineEntity';
@@ -308,10 +308,10 @@ class LinkTypesToolboxInner extends React.Component<LinkTypesToolboxInnerProps, 
     }
 
     private renderLinks(links: ReadonlyArray<LabelledLinkType>) {
-        const {workspace: {getExtensionCommands}} = this.props;
+        const {workspace: {getCommandBus}} = this.props;
         const {filteredLinks} = this.state;
 
-        const commands = getExtensionCommands(InstancesSearchExtension);
+        const commands = getCommandBus(InstancesSearchTopic);
         const event: InstancesSearchCommands['findCapabilities'] = {capabilities: []};
         commands.trigger('findCapabilities', event);
 
@@ -332,11 +332,11 @@ class LinkTypesToolboxInner extends React.Component<LinkTypesToolboxInnerProps, 
     }
 
     private onAddToFilter = (linkType: LinkTypeIri) => {
-        const {workspace: {getExtensionCommands}} = this.props;
+        const {workspace: {getCommandBus}} = this.props;
         const {filteredLinks} = this.state;
 
         if (filteredLinks.selection.length === 1) {
-            getExtensionCommands(InstancesSearchExtension)
+            getCommandBus(InstancesSearchTopic)
                 .trigger('setCriteria', {
                     criteria: {
                         refElement: filteredLinks.selection[0].id,

--- a/src/widgets/selection.tsx
+++ b/src/widgets/selection.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { shallowArrayEqual } from '../coreUtils/collections';
-import { EventObserver, EventTrigger } from '../coreUtils/events';
+import { EventObserver } from '../coreUtils/events';
 import {
     SyncStore, useEventStore, useFrameDebouncedStore, useSyncStoreWithComparator,
 } from '../coreUtils/hooks';
@@ -14,7 +14,6 @@ import {
 } from '../diagram/geometry';
 import { DiagramModel } from '../diagram/model';
 
-import type { ConnectionsMenuCommands } from './connectionsMenu';
 import {
     SelectionActionRemove, SelectionActionZoomToFit, SelectionActionLayout,
     SelectionActionExpand, SelectionActionConnections, SelectionActionGroup,
@@ -39,10 +38,6 @@ export interface SelectionProps {
      */
     itemMargin?: number;
     /**
-     * Event bus to send commands to {@link ConnectionMenu} component.
-     */
-    connectionsMenuCommands?: EventTrigger<ConnectionsMenuCommands>;
-    /**
      * {@link SelectionAction} items representing available actions on the selected elements.
      *
      * **Default**:
@@ -52,9 +47,7 @@ export interface SelectionProps {
      *   <SelectionActionLayout dock='nw' dockColumn={2} />
      *   <SelectionActionGroup dock='nw' dockColumn={3} />
      *   <SelectionActionRemove dock='ne' />
-     *   <SelectionActionConnections dock='e'
-     *       commands={props.connectionsMenuCommands}
-     *   />
+     *   <SelectionActionConnections dock='e' />
      *   <SelectionActionExpand dock='s' />
      * </>
      * ```
@@ -216,7 +209,6 @@ function SelectionBox(props: SelectionBoxProps) {
         model, canvas, selectedElements, highlightedBox,
         boxMargin = 5,
         itemMargin = 2,
-        connectionsMenuCommands,
         children,
     } = props;
 
@@ -263,9 +255,7 @@ function SelectionBox(props: SelectionBoxProps) {
                         <SelectionActionLayout dock='nw' dockColumn={2} />
                         <SelectionActionGroup dock='nw' dockColumn={3} />
                         <SelectionActionRemove dock='ne' />
-                        <SelectionActionConnections dock='e'
-                            commands={connectionsMenuCommands}
-                        />
+                        <SelectionActionConnections dock='e' />
                         <SelectionActionExpand dock='s' />
                     </>}
                 </div>

--- a/src/widgets/selectionAction.tsx
+++ b/src/widgets/selectionAction.tsx
@@ -2,7 +2,7 @@ import cx from 'clsx';
 import * as React from 'react';
 
 import { mapAbortedToNull } from '../coreUtils/async';
-import { EventObserver, EventTrigger } from '../coreUtils/events';
+import { EventObserver } from '../coreUtils/events';
 import {
     SyncStore, useEventStore, useFrameDebouncedStore, useObservedProperty, useSyncStore,
 } from '../coreUtils/hooks';
@@ -21,6 +21,9 @@ import { EntityElement, EntityGroup, iterateEntitiesOf } from '../editor/dataEle
 import type { EditorController } from '../editor/editorController';
 import { groupEntitiesAnimated, ungroupAllEntitiesAnimated } from '../editor/elementGrouping';
 
+import {
+    ConnectionsMenuExtension, InstancesSearchExtension, VisualAuthoringExtension,
+} from '../workspace/workspaceExtension';
 import { useWorkspace } from '../workspace/workspaceContext';
 
 import type { DockDirection } from './utility/viewportDock';
@@ -431,12 +434,7 @@ export function SelectionActionAnchor(props: SelectionActionAnchorProps) {
  *
  * @see {@link SelectionActionConnections}
  */
-export interface SelectionActionConnectionsProps extends SelectionActionStyleProps {
-    /**
-     * Event bus to send commands to {@link ConnectionMenu} component.
-     */
-    commands?: EventTrigger<ConnectionsMenuCommands>;
-}
+export interface SelectionActionConnectionsProps extends SelectionActionStyleProps {}
 
 /**
  * Selection action component to open a {@link ConnectionsMenu} for the selected entities.
@@ -444,8 +442,8 @@ export interface SelectionActionConnectionsProps extends SelectionActionStylePro
  * @category Components
  */
 export function SelectionActionConnections(props: SelectionActionConnectionsProps) {
-    const {className, title, commands, ...otherProps} = props;
-    const {model, overlay, translation: t} = useWorkspace();
+    const {className, title, ...otherProps} = props;
+    const {model, overlay, translation: t, getExtensionCommands} = useWorkspace();
 
     const menuOpened = useObservedProperty(
         overlay.events,
@@ -462,9 +460,14 @@ export function SelectionActionConnections(props: SelectionActionConnectionsProp
         }
     }
 
-    if (!(commands && entityCount > 0)) {
+    const commands = getExtensionCommands(ConnectionsMenuExtension);
+    const event: ConnectionsMenuCommands['findCapabilities'] = {capabilities: []};
+    commands.trigger('findCapabilities', event);
+
+    if (!(event.capabilities.length > 0 && entityCount > 0)) {
         return null;
     }
+
     return (
         <SelectionAction {...otherProps}
             className={cx(
@@ -490,12 +493,7 @@ export function SelectionActionConnections(props: SelectionActionConnectionsProp
  *
  * @see {@link SelectionActionAddToFilter}
  */
-export interface SelectionActionAddToFilterProps extends SelectionActionStyleProps {
-    /**
-     * Event bus to send commands to {@link InstancesSearch} component.
-     */
-    commands?: EventTrigger<InstancesSearchCommands>;
-}
+export interface SelectionActionAddToFilterProps extends SelectionActionStyleProps {}
 
 /**
  * Selection action component to add the selected entity to the {@link InstancesSearch} filter.
@@ -503,11 +501,15 @@ export interface SelectionActionAddToFilterProps extends SelectionActionStylePro
  * @category Components
  */
 export function SelectionActionAddToFilter(props: SelectionActionAddToFilterProps) {
-    const {className, title, commands, ...otherProps} = props;
-    const {model} = useCanvas();
-    const t = useTranslation();
+    const {className, title, ...otherProps} = props;
+    const {model, translation: t, getExtensionCommands} = useWorkspace();
+
     const elements = model.selection.filter((cell): cell is Element => cell instanceof Element);
-    if (!(commands && elements.length === 1)) {
+    const commands = getExtensionCommands(InstancesSearchExtension);
+    const event: InstancesSearchCommands['findCapabilities'] = {capabilities: []};
+    commands.trigger('findCapabilities', event);
+
+    if (!(event.capabilities.length > 0 && elements.length === 1)) {
         return null;
     }
     const [target] = elements;
@@ -606,7 +608,7 @@ export interface SelectionActionEstablishLinkProps extends SelectionActionStyleP
 export function SelectionActionEstablishLink(props: SelectionActionEstablishLinkProps) {
     const {className, title, ...otherProps} = props;
     const {canvas} = useCanvas();
-    const {model, editor, translation: t} = useWorkspace();
+    const {model, editor, translation: t, getExtensionCommands} = useWorkspace();
 
     const inAuthoringMode = useObservedProperty(
         editor.events, 'changeMode', () => editor.inAuthoringMode
@@ -641,9 +643,10 @@ export function SelectionActionEstablishLink(props: SelectionActionEstablishLink
             )}
             onMouseDown={e => {
                 const point = canvas.metrics.pageToPaperCoords(e.pageX, e.pageY);
-                editor.authoringCommands.trigger('startDragEdit', {
-                    operation: {mode: 'connect', source: target, point},
-                });
+                getExtensionCommands(VisualAuthoringExtension)
+                    .trigger('startDragEdit', {
+                        operation: {mode: 'connect', source: target, point},
+                    });
             }}
         />
     );

--- a/src/widgets/selectionAction.tsx
+++ b/src/widgets/selectionAction.tsx
@@ -22,8 +22,8 @@ import type { EditorController } from '../editor/editorController';
 import { groupEntitiesAnimated, ungroupAllEntitiesAnimated } from '../editor/elementGrouping';
 
 import {
-    ConnectionsMenuExtension, InstancesSearchExtension, VisualAuthoringExtension,
-} from '../workspace/workspaceExtension';
+    ConnectionsMenuTopic, InstancesSearchTopic, VisualAuthoringTopic,
+} from '../workspace/commandBusTopic';
 import { useWorkspace } from '../workspace/workspaceContext';
 
 import type { DockDirection } from './utility/viewportDock';
@@ -443,7 +443,7 @@ export interface SelectionActionConnectionsProps extends SelectionActionStylePro
  */
 export function SelectionActionConnections(props: SelectionActionConnectionsProps) {
     const {className, title, ...otherProps} = props;
-    const {model, overlay, translation: t, getExtensionCommands} = useWorkspace();
+    const {model, overlay, translation: t, getCommandBus} = useWorkspace();
 
     const menuOpened = useObservedProperty(
         overlay.events,
@@ -460,7 +460,7 @@ export function SelectionActionConnections(props: SelectionActionConnectionsProp
         }
     }
 
-    const commands = getExtensionCommands(ConnectionsMenuExtension);
+    const commands = getCommandBus(ConnectionsMenuTopic);
     const event: ConnectionsMenuCommands['findCapabilities'] = {capabilities: []};
     commands.trigger('findCapabilities', event);
 
@@ -502,10 +502,10 @@ export interface SelectionActionAddToFilterProps extends SelectionActionStylePro
  */
 export function SelectionActionAddToFilter(props: SelectionActionAddToFilterProps) {
     const {className, title, ...otherProps} = props;
-    const {model, translation: t, getExtensionCommands} = useWorkspace();
+    const {model, translation: t, getCommandBus} = useWorkspace();
 
     const elements = model.selection.filter((cell): cell is Element => cell instanceof Element);
-    const commands = getExtensionCommands(InstancesSearchExtension);
+    const commands = getCommandBus(InstancesSearchTopic);
     const event: InstancesSearchCommands['findCapabilities'] = {capabilities: []};
     commands.trigger('findCapabilities', event);
 
@@ -608,7 +608,7 @@ export interface SelectionActionEstablishLinkProps extends SelectionActionStyleP
 export function SelectionActionEstablishLink(props: SelectionActionEstablishLinkProps) {
     const {className, title, ...otherProps} = props;
     const {canvas} = useCanvas();
-    const {model, editor, translation: t, getExtensionCommands} = useWorkspace();
+    const {model, editor, translation: t, getCommandBus} = useWorkspace();
 
     const inAuthoringMode = useObservedProperty(
         editor.events, 'changeMode', () => editor.inAuthoringMode
@@ -643,7 +643,7 @@ export function SelectionActionEstablishLink(props: SelectionActionEstablishLink
             )}
             onMouseDown={e => {
                 const point = canvas.metrics.pageToPaperCoords(e.pageX, e.pageY);
-                getExtensionCommands(VisualAuthoringExtension)
+                getCommandBus(VisualAuthoringTopic)
                     .trigger('startDragEdit', {
                         operation: {mode: 'connect', source: target, point},
                     });

--- a/src/widgets/unifiedSearch/builtinSearchSections.tsx
+++ b/src/widgets/unifiedSearch/builtinSearchSections.tsx
@@ -6,7 +6,7 @@ import { ClassTree } from '../classTree';
 import { InstancesSearch, SearchCriteria } from '../instancesSearch';
 import { LinkTypesToolbox } from '../linksToolbox';
 
-import { InstancesSearchExtension } from '../../workspace/workspaceExtension';
+import { InstancesSearchTopic } from '../../workspace/commandBusTopic';
 import { useWorkspace } from '../../workspace/workspaceContext';
 
 import { useUnifiedSearchSection } from './searchSection';
@@ -67,13 +67,13 @@ export function SearchSectionEntities(props: {
     minSearchTermLength?: number;
 }) {
     const {searchTimeout = 600, minSearchTermLength = 3} = props;
-    const {getExtensionCommands} = useWorkspace();
+    const {getCommandBus} = useWorkspace();
     const {shouldRender, setSectionActive, searchStore} = useUnifiedSearchSection({
         searchTimeout,
         allowSubmit: term => term.length >= minSearchTermLength,
     });
 
-    const commands = getExtensionCommands(InstancesSearchExtension);
+    const commands = getCommandBus(InstancesSearchTopic);
     React.useEffect(() => {
         const listener = new EventObserver();
         listener.listen(commands, 'setCriteria', ({criteria}) => {

--- a/src/widgets/unifiedSearch/builtinSearchSections.tsx
+++ b/src/widgets/unifiedSearch/builtinSearchSections.tsx
@@ -1,10 +1,13 @@
 import * as React from 'react';
 
-import { Events, EventTrigger, EventObserver } from '../../coreUtils/events';
+import { EventObserver } from '../../coreUtils/events';
 
 import { ClassTree } from '../classTree';
-import { InstancesSearch, InstancesSearchCommands, SearchCriteria } from '../instancesSearch';
+import { InstancesSearch, SearchCriteria } from '../instancesSearch';
 import { LinkTypesToolbox } from '../linksToolbox';
+
+import { InstancesSearchExtension } from '../../workspace/workspaceExtension';
+import { useWorkspace } from '../../workspace/workspaceContext';
 
 import { useUnifiedSearchSection } from './searchSection';
 
@@ -28,12 +31,8 @@ export function SearchSectionElementTypes(props: {
      * @default 2
      */
     minSearchTermLength?: number;
-    /**
-     * Event bus to send commands to {@link InstancesSearch} component.
-     */
-    instancesSearchCommands?: EventTrigger<InstancesSearchCommands>;
 }) {
-    const {searchTimeout = 200, minSearchTermLength = 2, instancesSearchCommands} = props;
+    const {searchTimeout = 200, minSearchTermLength = 2} = props;
     const {searchStore, shouldRender} = useUnifiedSearchSection({
         searchTimeout,
         allowSubmit: term => term.length >= minSearchTermLength,
@@ -42,7 +41,6 @@ export function SearchSectionElementTypes(props: {
     return shouldRender ? (
         <ClassTree className={SECTION_ELEMENT_TYPES_CLASS}
             searchStore={searchStore}
-            instancesSearchCommands={instancesSearchCommands}
         />
     ) : null;
 }
@@ -67,26 +65,22 @@ export function SearchSectionEntities(props: {
      * @default 3
      */
     minSearchTermLength?: number;
-    /**
-     * Event bus to listen commands for {@link InstancesSearch} component.
-     */
-    instancesSearchCommands: Events<InstancesSearchCommands> & EventTrigger<InstancesSearchCommands>;
 }) {
-    const {searchTimeout = 600, minSearchTermLength = 3, instancesSearchCommands} = props;
+    const {searchTimeout = 600, minSearchTermLength = 3} = props;
+    const {getExtensionCommands} = useWorkspace();
     const {shouldRender, setSectionActive, searchStore} = useUnifiedSearchSection({
         searchTimeout,
         allowSubmit: term => term.length >= minSearchTermLength,
     });
 
+    const commands = getExtensionCommands(InstancesSearchExtension);
     React.useEffect(() => {
-        if (instancesSearchCommands) {
-            const listener = new EventObserver();
-            listener.listen(instancesSearchCommands, 'setCriteria', ({criteria}) => {
-                setSectionActive(true, criteriaAsSearchExtra(criteria));
-            });
-            return () => listener.stopListening();
-        }
-    }, [shouldRender, instancesSearchCommands]);
+        const listener = new EventObserver();
+        listener.listen(commands, 'setCriteria', ({criteria}) => {
+            setSectionActive(true, criteriaAsSearchExtra(criteria));
+        });
+        return () => listener.stopListening();
+    }, [shouldRender, commands]);
 
     return (
         <InstancesSearch className={SECTION_ENTITIES_CLASS}
@@ -99,7 +93,6 @@ export function SearchSectionEntities(props: {
             onAddElements={() => {
                 setSectionActive(false);
             }}
-            commands={instancesSearchCommands}
         />
     );
 }
@@ -132,12 +125,8 @@ export function SearchSectionLinkTypes(props: {
      * @default 1
      */
     minSearchTermLength?: number;
-    /**
-     * Event bus to send commands to {@link InstancesSearch} component.
-     */
-    instancesSearchCommands?: EventTrigger<InstancesSearchCommands>;
 }) {
-    const {searchTimeout = 200, minSearchTermLength = 1, instancesSearchCommands} = props;
+    const {searchTimeout = 200, minSearchTermLength = 1} = props;
     const {shouldRender, isSectionActive, searchStore} = useUnifiedSearchSection({
         searchTimeout,
         allowSubmit: term => term.length >= minSearchTermLength,
@@ -147,7 +136,6 @@ export function SearchSectionLinkTypes(props: {
         <LinkTypesToolbox className={SECTION_LINK_TYPES_CLASS}
             trackSelected={isSectionActive}
             searchStore={searchStore}
-            instancesSearchCommands={instancesSearchCommands}
         />
     ) : null;
 }

--- a/src/widgets/unifiedSearch/unifiedSearch.tsx
+++ b/src/widgets/unifiedSearch/unifiedSearch.tsx
@@ -15,7 +15,7 @@ import { getParentDockAlignment } from '../utility/viewportDock';
 // TODO: move into widgets
 import { DraggableHandle } from '../../workspace/draggableHandle';
 import { useWorkspace } from '../../workspace/workspaceContext';
-import { UnifiedSearchExtension } from '../../workspace/workspaceExtension';
+import { UnifiedSearchTopic } from '../../workspace/commandBusTopic';
 
 import { UnifiedSearchSectionContext } from './searchSection';
 
@@ -221,8 +221,8 @@ export function UnifiedSearch(props: UnifiedSearchProps) {
         [sections, searchStore, activeSection, setActiveSection, setExpanded]
     );
 
-    const {getExtensionCommands} = useWorkspace();
-    const commands = getExtensionCommands(UnifiedSearchExtension);
+    const {getCommandBus} = useWorkspace();
+    const commands = getCommandBus(UnifiedSearchTopic);
     const toggleInputRef = React.useRef<HTMLInputElement | null>(null);
     React.useEffect(() => {
         const onFocus = ({sectionKey}: UnifiedSearchCommands['focus']): void => {

--- a/src/widgets/visualAuthoring/authoredEntity.tsx
+++ b/src/widgets/visualAuthoring/authoredEntity.tsx
@@ -9,6 +9,7 @@ import { Element } from '../../diagram/elements';
 
 import { EntityElement } from '../../editor/dataElements';
 
+import { VisualAuthoringExtension } from '../../workspace/workspaceExtension';
 import { useWorkspace } from '../../workspace/workspaceContext';
 
 /**
@@ -61,7 +62,7 @@ export function useAuthoredEntity(
     data: ElementModel | undefined,
     shouldLoad: boolean
 ): AuthoredEntityContext {
-    const {editor} = useWorkspace();
+    const {editor, getExtensionCommands} = useWorkspace();
 
     const entity = editor.inAuthoringMode ? data : undefined;
 
@@ -110,7 +111,8 @@ export function useAuthoredEntity(
             ? undefined : Boolean(allowedActions & AllowedActions.Delete),
         onEdit: (target: Element) => {
             if (target instanceof EntityElement) {
-                editor.authoringCommands.trigger('editEntity', {target});
+                getExtensionCommands(VisualAuthoringExtension)
+                    .trigger('editEntity', {target});
             }
         },
         onDelete: () => {

--- a/src/widgets/visualAuthoring/authoredEntity.tsx
+++ b/src/widgets/visualAuthoring/authoredEntity.tsx
@@ -9,7 +9,7 @@ import { Element } from '../../diagram/elements';
 
 import { EntityElement } from '../../editor/dataElements';
 
-import { VisualAuthoringExtension } from '../../workspace/workspaceExtension';
+import { VisualAuthoringTopic } from '../../workspace/commandBusTopic';
 import { useWorkspace } from '../../workspace/workspaceContext';
 
 /**
@@ -62,7 +62,7 @@ export function useAuthoredEntity(
     data: ElementModel | undefined,
     shouldLoad: boolean
 ): AuthoredEntityContext {
-    const {editor, getExtensionCommands} = useWorkspace();
+    const {editor, getCommandBus} = useWorkspace();
 
     const entity = editor.inAuthoringMode ? data : undefined;
 
@@ -111,7 +111,7 @@ export function useAuthoredEntity(
             ? undefined : Boolean(allowedActions & AllowedActions.Delete),
         onEdit: (target: Element) => {
             if (target instanceof EntityElement) {
-                getExtensionCommands(VisualAuthoringExtension)
+                getCommandBus(VisualAuthoringTopic)
                     .trigger('editEntity', {target});
             }
         },

--- a/src/widgets/visualAuthoring/dragEditLayer.tsx
+++ b/src/widgets/visualAuthoring/dragEditLayer.tsx
@@ -18,6 +18,7 @@ import { Spinner } from '../../diagram/spinner';
 import { TemporaryState } from '../../editor/authoringState';
 import { EntityElement, RelationLink } from '../../editor/dataElements';
 
+import { VisualAuthoringExtension } from '../../workspace/workspaceExtension';
 import { type WorkspaceContext, useWorkspace } from '../../workspace/workspaceContext';
 
 export interface DragEditLayerProps {
@@ -318,7 +319,7 @@ class DragEditLayerInner extends React.Component<DragEditLayerInnerProps, State>
     };
 
     private async executeEditOperation(selectedPosition: Vector): Promise<void> {
-        const {operation, canvas, workspace: {model, editor}} = this.props;
+        const {operation, canvas, workspace: {model, editor, getExtensionCommands}} = this.props;
 
         try {
             const {targetElement, connectionsToAny, connectionsToTarget} = this.state;
@@ -366,16 +367,18 @@ class DragEditLayerInner extends React.Component<DragEditLayerInnerProps, State>
                 if (targetElement) {
                     const focusedLink = modifiedLink || this.oldLink;
                     model.setSelection([focusedLink!]);
-                    editor.authoringCommands.trigger('editRelation', {target: focusedLink!});
+                    getExtensionCommands(VisualAuthoringExtension)
+                        .trigger('editRelation', {target: focusedLink!});
                 } else if (createdTarget && modifiedLink) {
                     model.setSelection([createdTarget]);
                     const source = model.getElement(modifiedLink.sourceId) as EntityElement;
-                    editor.authoringCommands.trigger('findOrCreateEntity', {
-                        link: modifiedLink,
-                        source,
-                        target: createdTarget,
-                        targetIsNew: true,
-                    });
+                    getExtensionCommands(VisualAuthoringExtension)
+                        .trigger('findOrCreateEntity', {
+                            link: modifiedLink,
+                            source,
+                            target: createdTarget,
+                            targetIsNew: true,
+                        });
                 }
             }
         } finally {

--- a/src/widgets/visualAuthoring/dragEditLayer.tsx
+++ b/src/widgets/visualAuthoring/dragEditLayer.tsx
@@ -18,7 +18,7 @@ import { Spinner } from '../../diagram/spinner';
 import { TemporaryState } from '../../editor/authoringState';
 import { EntityElement, RelationLink } from '../../editor/dataElements';
 
-import { VisualAuthoringExtension } from '../../workspace/workspaceExtension';
+import { VisualAuthoringTopic } from '../../workspace/commandBusTopic';
 import { type WorkspaceContext, useWorkspace } from '../../workspace/workspaceContext';
 
 export interface DragEditLayerProps {
@@ -319,7 +319,7 @@ class DragEditLayerInner extends React.Component<DragEditLayerInnerProps, State>
     };
 
     private async executeEditOperation(selectedPosition: Vector): Promise<void> {
-        const {operation, canvas, workspace: {model, editor, getExtensionCommands}} = this.props;
+        const {operation, canvas, workspace: {model, editor, getCommandBus}} = this.props;
 
         try {
             const {targetElement, connectionsToAny, connectionsToTarget} = this.state;
@@ -367,12 +367,12 @@ class DragEditLayerInner extends React.Component<DragEditLayerInnerProps, State>
                 if (targetElement) {
                     const focusedLink = modifiedLink || this.oldLink;
                     model.setSelection([focusedLink!]);
-                    getExtensionCommands(VisualAuthoringExtension)
+                    getCommandBus(VisualAuthoringTopic)
                         .trigger('editRelation', {target: focusedLink!});
                 } else if (createdTarget && modifiedLink) {
                     model.setSelection([createdTarget]);
                     const source = model.getElement(modifiedLink.sourceId) as EntityElement;
-                    getExtensionCommands(VisualAuthoringExtension)
+                    getCommandBus(VisualAuthoringTopic)
                         .trigger('findOrCreateEntity', {
                             link: modifiedLink,
                             source,

--- a/src/widgets/visualAuthoring/visualAuthoring.tsx
+++ b/src/widgets/visualAuthoring/visualAuthoring.tsx
@@ -17,7 +17,7 @@ import { EditEntityForm } from '../../forms/editEntityForm';
 import { FindOrCreateEntityForm } from '../../forms/findOrCreateEntityForm';
 import { RenameLinkForm } from '../../forms/renameLinkForm';
 
-import { VisualAuthoringExtension } from '../../workspace/workspaceExtension';
+import { VisualAuthoringTopic } from '../../workspace/commandBusTopic';
 import { useWorkspace } from '../../workspace/workspaceContext';
 
 import { AuthoredEntityDecorator } from './authoredEntityDecorator';
@@ -94,7 +94,7 @@ export interface VisualAuthoringCommands {
  */
 export function VisualAuthoring(props: VisualAuthoringProps) {
     const {propertyEditor} = props;
-    const {model, view, editor, overlay, translation: t, getExtensionCommands} = useWorkspace();
+    const {model, view, editor, overlay, translation: t, getCommandBus} = useWorkspace();
 
     React.useLayoutEffect(() => {
         const listener = new EventObserver();
@@ -136,7 +136,7 @@ export function VisualAuthoring(props: VisualAuthoringProps) {
     }, []);
 
     React.useLayoutEffect(() => {
-        const commands = getExtensionCommands(VisualAuthoringExtension);
+        const commands = getCommandBus(VisualAuthoringTopic);
         const listener = new EventObserver();
 
         listener.listen(commands, 'startDragEdit', ({operation}) => {

--- a/src/widgets/visualAuthoring/visualAuthoring.tsx
+++ b/src/widgets/visualAuthoring/visualAuthoring.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { EventObserver } from '../../coreUtils/events';
 
-import { ElementModel, equalLinks, equalProperties } from '../../data/model';
+import { ElementModel } from '../../data/model';
 import { defineCanvasWidget } from '../../diagram/canvasWidget';
 import { Link } from '../../diagram/elements';
 import { Size } from '../../diagram/geometry';
@@ -17,6 +17,7 @@ import { EditEntityForm } from '../../forms/editEntityForm';
 import { FindOrCreateEntityForm } from '../../forms/findOrCreateEntityForm';
 import { RenameLinkForm } from '../../forms/renameLinkForm';
 
+import { VisualAuthoringExtension } from '../../workspace/workspaceExtension';
 import { useWorkspace } from '../../workspace/workspaceContext';
 
 import { AuthoredEntityDecorator } from './authoredEntityDecorator';
@@ -93,7 +94,7 @@ export interface VisualAuthoringCommands {
  */
 export function VisualAuthoring(props: VisualAuthoringProps) {
     const {propertyEditor} = props;
-    const {model, view, editor, overlay, translation: t} = useWorkspace();
+    const {model, view, editor, overlay, translation: t, getExtensionCommands} = useWorkspace();
 
     React.useLayoutEffect(() => {
         const listener = new EventObserver();
@@ -135,9 +136,10 @@ export function VisualAuthoring(props: VisualAuthoringProps) {
     }, []);
 
     React.useLayoutEffect(() => {
+        const commands = getExtensionCommands(VisualAuthoringExtension);
         const listener = new EventObserver();
 
-        listener.listen(editor.authoringCommands, 'startDragEdit', ({operation}) => {
+        listener.listen(commands, 'startDragEdit', ({operation}) => {
             const onFinishEditing = () => {
                 view.setCanvasWidget('dragEditLayer', null);
             };
@@ -149,7 +151,7 @@ export function VisualAuthoring(props: VisualAuthoringProps) {
             view.setCanvasWidget('dragEditLayer', {element: dragEditLayer, attachment: 'overElements'});
         });
 
-        listener.listen(editor.authoringCommands, 'editEntity', ({target}) => {
+        listener.listen(commands, 'editEntity', ({target}) => {
             const onSubmit = (newData: ElementModel) => {
                 overlay.hideDialog();
                 editor.changeEntity(target.data.id, newData);
@@ -179,7 +181,7 @@ export function VisualAuthoring(props: VisualAuthoringProps) {
             });
         });
 
-        listener.listen(editor.authoringCommands, 'findOrCreateEntity', e => {
+        listener.listen(commands, 'findOrCreateEntity', e => {
             const {link, source, target, targetIsNew} = e;
             const content = (
                 <FindOrCreateEntityForm source={source}
@@ -189,7 +191,7 @@ export function VisualAuthoring(props: VisualAuthoringProps) {
                     onAfterApply={() => {
                         overlay.hideDialog();
                         if (AuthoringState.isAddedEntity(editor.authoringState, target.iri)) {
-                            editor.authoringCommands.trigger('editEntity', {target});
+                            commands.trigger('editEntity', {target});
                         }
                     }}
                     onCancel={() => overlay.hideDialog()}
@@ -207,7 +209,7 @@ export function VisualAuthoring(props: VisualAuthoringProps) {
             });
         });
 
-        listener.listen(editor.authoringCommands, 'editRelation', ({target: link}) => {
+        listener.listen(commands, 'editRelation', ({target: link}) => {
             const content = (
                 <EditRelationForm originalLink={link}
                     source={model.getElement(link.sourceId) as EntityElement}
@@ -216,7 +218,7 @@ export function VisualAuthoring(props: VisualAuthoringProps) {
                         // Close current dialog before opening a new one to avoid
                         // target temporary link removal
                         overlay.hideDialog();
-                        editor.authoringCommands.trigger('editRelation', {target: newTarget});
+                        commands.trigger('editRelation', {target: newTarget});
                     }}
                     onAfterApply={() => overlay.hideDialog()}
                     onCancel={() => overlay.hideDialog()}
@@ -238,7 +240,7 @@ export function VisualAuthoring(props: VisualAuthoringProps) {
             });
         });
 
-        listener.listen(editor.authoringCommands, 'renameLink', ({target: link}) => {
+        listener.listen(commands, 'renameLink', ({target: link}) => {
             const defaultSize: Size = {width: 300, height: 165};
             overlay.showDialog({
                 target: link,

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -248,9 +248,8 @@ export {
     ProcessedTypeStyle, useWorkspace,
 } from './workspace/workspaceContext';
 export {
-    WorkspaceExtension,
-    ConnectionsMenuExtension, InstancesSearchExtension, UnifiedSearchExtension,
-    VisualAuthoringExtension,
-} from './workspace/workspaceExtension';
+    CommandBusTopic,
+    ConnectionsMenuTopic, InstancesSearchTopic, UnifiedSearchTopic, VisualAuthoringTopic,
+} from './workspace/commandBusTopic';
 export * from './workspace/workspaceLayout';
 export { WorkspaceRoot, WorkspaceRootProps } from './workspace/workspaceRoot';

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -247,5 +247,10 @@ export {
     WorkspaceGroupParams, WorkspaceUngroupAllParams, WorkspaceUngroupSomeParams,
     ProcessedTypeStyle, useWorkspace,
 } from './workspace/workspaceContext';
+export {
+    WorkspaceExtension,
+    ConnectionsMenuExtension, InstancesSearchExtension, UnifiedSearchExtension,
+    VisualAuthoringExtension,
+} from './workspace/workspaceExtension';
 export * from './workspace/workspaceLayout';
 export { WorkspaceRoot, WorkspaceRootProps } from './workspace/workspaceRoot';

--- a/src/workspace/classicWorkspace.tsx
+++ b/src/workspace/classicWorkspace.tsx
@@ -1,19 +1,16 @@
 import * as React from 'react';
 
-import { EventSource } from '../coreUtils/events';
 import { useTranslation } from '../coreUtils/i18n';
 
 import { defineCanvasWidget } from '../diagram/canvasWidget';
 
 import { Canvas } from '../widgets/canvas';
 import { ClassTree, ClassTreeProps } from '../widgets/classTree';
-import {
-    ConnectionsMenu, ConnectionsMenuCommands,
-} from '../widgets/connectionsMenu';
+import { ConnectionsMenu } from '../widgets/connectionsMenu';
 import { DropOnCanvas } from '../widgets/dropOnCanvas';
 import { Halo } from '../widgets/halo';
 import { HaloLink } from '../widgets/haloLink';
-import { InstancesSearch, InstancesSearchProps, InstancesSearchCommands } from '../widgets/instancesSearch';
+import { InstancesSearch, InstancesSearchProps } from '../widgets/instancesSearch';
 import { LinkTypesToolbox, LinkTypesToolboxProps } from '../widgets/linksToolbox';
 import { Navigator } from '../widgets/navigator';
 import { Selection } from '../widgets/selection';
@@ -79,12 +76,6 @@ export function ClassicWorkspace(props: ClassicWorkspaceProps) {
     } = props;
 
     const t = useTranslation();
-    const [connectionsMenuCommands] = React.useState(() =>
-        props.connectionsMenuCommands ?? new EventSource<ConnectionsMenuCommands>()
-    );
-    const [instancesSearchCommands] = React.useState(() =>
-        props.instancesSearchCommands ?? new EventSource<InstancesSearchCommands>()
-    );
 
     return (
         <WorkspaceRoot colorScheme={colorScheme}>
@@ -93,42 +84,26 @@ export function ClassicWorkspace(props: ClassicWorkspaceProps) {
                     {...leftColumn}>
                     <WorkspaceLayoutItem id='classes'
                         heading={t.text('classic_workspace.class_tree.heading')}>
-                        <ClassTree {...classTree}
-                            instancesSearchCommands={instancesSearchCommands}
-                        />
+                        <ClassTree {...classTree} />
                     </WorkspaceLayoutItem>
                     <WorkspaceLayoutItem id='instances'
                         heading={t.text('classic_workspace.instances.heading')}>
-                        <InstancesSearch {...instancesSearch}
-                            commands={instancesSearchCommands}
-                        />
+                        <InstancesSearch {...instancesSearch} />
                     </WorkspaceLayoutItem>
                 </WorkspaceLayoutColumn>
                 <WorkspaceLayoutItem id='canvas'>
                     <Canvas {...canvas}>
                         <VisualAuthoring {...visualAuthoring} />
                         {connectionsMenu === null ? null : (
-                            <ConnectionsMenu {...connectionsMenu}
-                                commands={connectionsMenuCommands}
-                                instancesSearchCommands={instancesSearchCommands}
-                            />
+                            <ConnectionsMenu {...connectionsMenu} />
                         )}
                         {dropOnCanvas === null ? null : <DropOnCanvas {...dropOnCanvas} />}
                         {halo === null ? null : (
-                            <Halo {...halo}
-                                instancesSearchCommands={instancesSearchCommands}
-                                connectionsMenuCommands={
-                                    connectionsMenu === null ? undefined : connectionsMenuCommands
-                                }
-                            />
+                            <Halo {...halo} />
                         )}
                         {haloLink === null ? null : <HaloLink {...haloLink} />}
                         {selection === null ? null : (
-                            <Selection {...selection}
-                                connectionsMenuCommands={
-                                    connectionsMenu === null ? undefined : connectionsMenuCommands
-                                }
-                            />
+                            <Selection {...selection} />
                         )}
                         {navigator === null ? null : <Navigator dock='se' {...navigator} />}
                         {toolbar === null ? null : <ClassicToolbar dock='nw' {...toolbar} />}
@@ -141,9 +116,7 @@ export function ClassicWorkspace(props: ClassicWorkspaceProps) {
                     {...rightColumn}>
                     <WorkspaceLayoutItem id='connections'
                         heading={t.text('classic_workspace.connections.heading')}>
-                        <LinkTypesToolbox {...linkToolbox}
-                            instancesSearchCommands={instancesSearchCommands}
-                        />
+                        <LinkTypesToolbox {...linkToolbox} />
                     </WorkspaceLayoutItem>
                 </WorkspaceLayoutColumn>
             </WorkspaceLayoutRow>

--- a/src/workspace/commandBusTopic.ts
+++ b/src/workspace/commandBusTopic.ts
@@ -6,39 +6,35 @@ import type { UnifiedSearchCommands } from '../widgets/unifiedSearch';
 import type { VisualAuthoringCommands } from '../widgets/visualAuthoring';
 
 /**
- * Represents a workspace extension definition.
- *
- * Currently, an extension is defined as having a common event bus to
- * communicate between different components.
+ * Represents a definition for an event bus to communicate
+ * between related components with the same topic.
  */
-export class WorkspaceExtension<T> {
+export class CommandBusTopic<T> {
     private __commandsMarker: Events<T> | undefined;
 
     private constructor() {}
 
     /**
-     * Defines a new workspace extension.
-     *
-     * **Experimental**: this feature will likely change in the future.
+     * Defines a new command event topic.
      */
     static define<T>() {
-        return new WorkspaceExtension<T>();
+        return new CommandBusTopic<T>();
     }
 }
 
 /**
  * Event bus to connect {@link ConnectionMenu} to other components.
  */
-export const ConnectionsMenuExtension = WorkspaceExtension.define<ConnectionsMenuCommands>();
+export const ConnectionsMenuTopic = CommandBusTopic.define<ConnectionsMenuCommands>();
 /**
  * Event bus to connect {@link InstancesSearch} to other components.
  */
-export const InstancesSearchExtension = WorkspaceExtension.define<InstancesSearchCommands>();
+export const InstancesSearchTopic = CommandBusTopic.define<InstancesSearchCommands>();
 /**
  * Event bus to connect {@link UnifiedSearch} to other components.
  */
-export const UnifiedSearchExtension = WorkspaceExtension.define<UnifiedSearchCommands>();
+export const UnifiedSearchTopic = CommandBusTopic.define<UnifiedSearchCommands>();
 /**
  * Event bus to connect {@link VisualAuthoring} to other components.
  */
-export const VisualAuthoringExtension = WorkspaceExtension.define<VisualAuthoringCommands>();
+export const VisualAuthoringTopic = CommandBusTopic.define<VisualAuthoringCommands>();

--- a/src/workspace/defaultWorkspace.tsx
+++ b/src/workspace/defaultWorkspace.tsx
@@ -1,16 +1,12 @@
 import * as React from 'react';
 
-import { Events, EventSource, EventTrigger } from '../coreUtils/events';
 import { useTranslation } from '../coreUtils/i18n';
 
 import { Canvas, CanvasProps } from '../widgets/canvas';
-import {
-    ConnectionsMenu, ConnectionsMenuProps, ConnectionsMenuCommands,
-} from '../widgets/connectionsMenu';
+import { ConnectionsMenu, ConnectionsMenuProps } from '../widgets/connectionsMenu';
 import { DropOnCanvas, DropOnCanvasProps } from '../widgets/dropOnCanvas';
 import { Halo, HaloProps } from '../widgets/halo';
 import { HaloLink, HaloLinkProps } from '../widgets/haloLink';
-import type { InstancesSearchCommands } from '../widgets/instancesSearch';
 import { Navigator, NavigatorProps } from '../widgets/navigator';
 import { Selection, SelectionProps } from '../widgets/selection';
 import { Toolbar, ToolbarProps } from '../widgets/toolbar';
@@ -19,7 +15,7 @@ import {
     ToolbarActionLayout, ToolbarLanguageSelector, WorkspaceLanguage,
 } from '../widgets/toolbarAction';
 import {
-    UnifiedSearch, UnifiedSearchProps, UnifiedSearchCommands, UnifiedSearchSection,
+    UnifiedSearch, UnifiedSearchProps, UnifiedSearchSection,
     SearchSectionElementTypes,
     SearchSectionEntities,
     SearchSectionLinkTypes,
@@ -95,24 +91,6 @@ export interface BaseDefaultWorkspaceProps {
      * If specified as `null`, the component will not be rendered.
      */
     zoomControl?: Partial<ZoomControlProps> | null;
-    /**
-     * Event bus to connect {@link UnifiedSearch} to other components.
-     *
-     * If not specified, an internal instance will be automatically created.
-     */
-    searchCommands?: Events<UnifiedSearchCommands> & EventTrigger<UnifiedSearchCommands>;
-    /**
-     * Event bus to connect {@link ConnectionMenu} to other components.
-     *
-     * If not specified, an internal instance will be automatically created.
-     */
-    connectionsMenuCommands?: Events<ConnectionsMenuCommands> & EventTrigger<ConnectionsMenuCommands>;
-    /**
-     * Event bus to connect {@link InstancesSearch} to other components.
-     *
-     * If not specified, an internal instance will be automatically created.
-     */
-    instancesSearchCommands?: Events<InstancesSearchCommands> & EventTrigger<InstancesSearchCommands>;
 }
 
 /**
@@ -193,15 +171,6 @@ export function DefaultWorkspace(props: DefaultWorkspaceProps) {
     } = props;
 
     const t = useTranslation();
-    const [searchCommands] = React.useState(() =>
-        props.searchCommands ?? new EventSource<UnifiedSearchCommands>()
-    );
-    const [connectionsMenuCommands] = React.useState(() =>
-        props.connectionsMenuCommands ?? new EventSource<ConnectionsMenuCommands>()
-    );
-    const [instancesSearchCommands] = React.useState(() =>
-        props.instancesSearchCommands ?? new EventSource<InstancesSearchCommands>()
-    );
 
     const menuContent = menu === null ? null : (
         menu ?? <>
@@ -226,61 +195,31 @@ export function DefaultWorkspace(props: DefaultWorkspaceProps) {
             key: 'elementTypes',
             label: t.text('default_workspace.search_section_entity_types.label'),
             title: t.text('default_workspace.search_section_entity_types.title'),
-            component: (
-                <SearchSectionElementTypes
-                    instancesSearchCommands={instancesSearchCommands}
-                />
-            )
+            component: <SearchSectionElementTypes />,
         },
         {
             key: 'entities',
             label: t.text('default_workspace.search_section_entities.label'),
             title: t.text('default_workspace.search_section_entities.title'),
-            component: (
-                <SearchSectionEntities
-                    instancesSearchCommands={instancesSearchCommands}
-                />
-            )
+            component: <SearchSectionEntities />,
         },
         {
             key: 'linkTypes',
             label: t.text('default_workspace.search_section_link_types.label'),
             title: t.text('default_workspace.search_section_link_types.title'),
-            component: (
-                <SearchSectionLinkTypes
-                    instancesSearchCommands={instancesSearchCommands}
-                />
-            )
+            component: <SearchSectionLinkTypes />,
         }
-    ], [instancesSearchCommands]);
+    ], []);
 
     return (
         <WorkspaceRoot colorScheme={colorScheme}>
             <Canvas {...canvas}>
                 <VisualAuthoring {...visualAuthoring} />
-                {connectionsMenu === null ? null : (
-                    <ConnectionsMenu {...connectionsMenu}
-                        commands={connectionsMenuCommands}
-                        instancesSearchCommands={instancesSearchCommands}
-                    />
-                )}
+                {connectionsMenu === null ? null : <ConnectionsMenu {...connectionsMenu} />}
                 {dropOnCanvas === null ? null : <DropOnCanvas {...dropOnCanvas} />}
-                {halo === null ? null : (
-                    <Halo {...halo}
-                        instancesSearchCommands={instancesSearchCommands}
-                        connectionsMenuCommands={
-                            connectionsMenu === null ? undefined : connectionsMenuCommands
-                        }
-                    />
-                )}
+                {halo === null ? null : <Halo {...halo} />}
                 {haloLink === null ? null : <HaloLink {...haloLink} />}
-                {selection === null ? null : (
-                    <Selection {...selection}
-                        connectionsMenuCommands={
-                            connectionsMenu === null ? undefined : connectionsMenuCommands
-                        }
-                    />
-                )}
+                {selection === null ? null : <Selection {...selection} />}
                 {zoomControl === null ? null : (
                     <ZoomControl dock='w'
                         {...zoomControl}
@@ -297,7 +236,6 @@ export function DefaultWorkspace(props: DefaultWorkspaceProps) {
                     {search === null ? null : (
                         <UnifiedSearch {...search}
                             sections={search?.sections ?? defaultSections}
-                            commands={searchCommands}
                         />
                     )}
                 </Toolbar>

--- a/src/workspace/workspace.tsx
+++ b/src/workspace/workspace.tsx
@@ -34,7 +34,7 @@ import { OverlayController } from '../editor/overlayController';
 import { DefaultLinkTemplate } from '../templates/defaultLinkTemplate';
 import { StandardTemplate } from '../templates/standardTemplate';
 
-import type { WorkspaceExtension } from './workspaceExtension';
+import type { CommandBusTopic } from './commandBusTopic';
 import {
     WorkspaceContext, WorkspaceEventKey, ProcessedTypeStyle,
 } from './workspaceContext';
@@ -132,7 +132,7 @@ export class Workspace extends React.Component<WorkspaceProps> {
     private readonly listener = new EventObserver();
     private readonly cancellation = new AbortController();
 
-    private readonly extensionCommands = new WeakMap<WorkspaceExtension<any>, EventSource<any>>();
+    private readonly extensionCommands = new WeakMap<CommandBusTopic<any>, EventSource<any>>();
 
     private readonly resolveTypeStyle: TypeStyleResolver;
     private readonly cachedTypeStyles: WeakMap<ReadonlyArray<ElementTypeIri>, ProcessedTypeStyle>;
@@ -209,7 +209,7 @@ export class Workspace extends React.Component<WorkspaceProps> {
             overlay,
             translation,
             disposeSignal: this.cancellation.signal,
-            getExtensionCommands: this.getExtensionCommands,
+            getCommandBus: this.getCommandBus,
             getElementStyle: this.getElementStyle,
             getElementTypeStyle: this.getElementTypeStyle,
             performLayout: this.onPerformLayout,
@@ -282,7 +282,7 @@ export class Workspace extends React.Component<WorkspaceProps> {
         overlay.dispose();
     }
 
-    private getExtensionCommands: WorkspaceContext['getExtensionCommands'] = (extension) => {
+    private getCommandBus: WorkspaceContext['getCommandBus'] = (extension) => {
         let commands = this.extensionCommands.get(extension);
         if (!commands) {
             commands = new EventSource();

--- a/src/workspace/workspace.tsx
+++ b/src/workspace/workspace.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { hcl } from 'd3-color';
 
 import { shallowArrayEqual } from '../coreUtils/collections';
-import { Events, EventObserver, EventSource, EventTrigger } from '../coreUtils/events';
+import { EventObserver, EventSource } from '../coreUtils/events';
 import { HashMap } from '../coreUtils/hashMap';
 import { LabelLanguageSelector, TranslationBundle, TranslatedText } from '../coreUtils/i18n';
 
@@ -24,7 +24,7 @@ import {
 import { SharedCanvasState, IriClickEvent } from '../diagram/sharedCanvasState';
 
 import { DataDiagramModel } from '../editor/dataDiagramModel';
-import { EntityGroup, EntityGroupItem } from '../editor/dataElements';
+import { EntityElement, EntityGroup, EntityGroupItem } from '../editor/dataElements';
 import { EditorController } from '../editor/editorController';
 import {
     groupEntitiesAnimated, ungroupAllEntitiesAnimated, ungroupSomeEntitiesAnimated,
@@ -34,12 +34,10 @@ import { OverlayController } from '../editor/overlayController';
 import { DefaultLinkTemplate } from '../templates/defaultLinkTemplate';
 import { StandardTemplate } from '../templates/standardTemplate';
 
-import type { VisualAuthoringCommands } from '../widgets/visualAuthoring';
-
+import type { WorkspaceExtension } from './workspaceExtension';
 import {
     WorkspaceContext, WorkspaceEventKey, ProcessedTypeStyle,
 } from './workspaceContext';
-import { EntityElement } from '../workspace';
 
 /**
  * Props for {@link Workspace} component.
@@ -75,12 +73,6 @@ export interface WorkspaceProps {
      * Provides a strategy to rename diagram links (change labels).
      */
     renameLinkProvider?: RenameLinkProvider;
-    /**
-     * Event bus to connect {@link VisualAuthoring} to other components.
-     *
-     * If not specified, an internal instance will be automatically created.
-     */
-    authoringCommands?: Events<VisualAuthoringCommands> & EventTrigger<VisualAuthoringCommands>;
     /**
      * Overrides how a single label gets selected from multiple of them based on target language.
      */
@@ -140,6 +132,8 @@ export class Workspace extends React.Component<WorkspaceProps> {
     private readonly listener = new EventObserver();
     private readonly cancellation = new AbortController();
 
+    private readonly extensionCommands = new WeakMap<WorkspaceExtension<any>, EventSource<any>>();
+
     private readonly resolveTypeStyle: TypeStyleResolver;
     private readonly cachedTypeStyles: WeakMap<ReadonlyArray<ElementTypeIri>, ProcessedTypeStyle>;
     private readonly cachedGroupStyles: WeakMap<ReadonlyArray<EntityGroupItem>, ProcessedTypeStyle>;
@@ -157,7 +151,6 @@ export class Workspace extends React.Component<WorkspaceProps> {
             metadataProvider,
             validationProvider,
             renameLinkProvider,
-            authoringCommands = new EventSource(),
             typeStyleResolver,
             selectLabelLanguage,
             defaultLanguage = DEFAULT_LANGUAGE,
@@ -190,7 +183,6 @@ export class Workspace extends React.Component<WorkspaceProps> {
 
         const editor = new EditorController({
             model,
-            authoringCommands,
             metadataProvider,
             validationProvider,
         });
@@ -217,6 +209,7 @@ export class Workspace extends React.Component<WorkspaceProps> {
             overlay,
             translation,
             disposeSignal: this.cancellation.signal,
+            getExtensionCommands: this.getExtensionCommands,
             getElementStyle: this.getElementStyle,
             getElementTypeStyle: this.getElementTypeStyle,
             performLayout: this.onPerformLayout,
@@ -288,6 +281,15 @@ export class Workspace extends React.Component<WorkspaceProps> {
         editor.dispose();
         overlay.dispose();
     }
+
+    private getExtensionCommands: WorkspaceContext['getExtensionCommands'] = (extension) => {
+        let commands = this.extensionCommands.get(extension);
+        if (!commands) {
+            commands = new EventSource();
+            this.extensionCommands.set(extension, commands);
+        }
+        return commands;
+    };
 
     private getElementStyle: WorkspaceContext['getElementStyle'] = element => {
         if (element instanceof EntityElement) {

--- a/src/workspace/workspaceContext.ts
+++ b/src/workspace/workspaceContext.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import type { Events, EventTrigger } from '../coreUtils/events';
 import type { Translation } from '../coreUtils/i18n';
 
 import type { ElementIri, ElementTypeIri } from '../data/model';
@@ -13,6 +14,8 @@ import type { DataDiagramModel } from '../editor/dataDiagramModel';
 import type { EntityElement, EntityGroup } from '../editor/dataElements';
 import type { EditorController } from '../editor/editorController';
 import type { OverlayController } from '../editor/overlayController';
+
+import type { WorkspaceExtension } from './workspaceExtension';
 
 /**
  * Represents a context for the whole workspace, its stores and services.
@@ -44,7 +47,14 @@ export interface WorkspaceContext {
      * Cancellation signal that becomes aborted when the workspace is disposed.
      */
     readonly disposeSignal: AbortSignal;
-
+    /**
+     * Gets a common command event bus for the given definition which allows interaction
+     * between different components.
+     *
+     * The returned event bus will share triggered events between all observers for
+     * the same definition.
+     */
+    readonly getExtensionCommands: <T>(definition: WorkspaceExtension<T>) => Events<T> & EventTrigger<T>;
     /**
      * Computes a style to display target element in various parts of the UI.
      */

--- a/src/workspace/workspaceContext.ts
+++ b/src/workspace/workspaceContext.ts
@@ -15,7 +15,7 @@ import type { EntityElement, EntityGroup } from '../editor/dataElements';
 import type { EditorController } from '../editor/editorController';
 import type { OverlayController } from '../editor/overlayController';
 
-import type { WorkspaceExtension } from './workspaceExtension';
+import type { CommandBusTopic } from './commandBusTopic';
 
 /**
  * Represents a context for the whole workspace, its stores and services.
@@ -48,13 +48,13 @@ export interface WorkspaceContext {
      */
     readonly disposeSignal: AbortSignal;
     /**
-     * Gets a common command event bus for the given definition which allows interaction
-     * between different components.
+     * Gets a common command event bus for the given topic definition which allows
+     * interaction between related components.
      *
      * The returned event bus will share triggered events between all observers for
      * the same definition.
      */
-    readonly getExtensionCommands: <T>(definition: WorkspaceExtension<T>) => Events<T> & EventTrigger<T>;
+    readonly getCommandBus: <T>(definition: CommandBusTopic<T>) => Events<T> & EventTrigger<T>;
     /**
      * Computes a style to display target element in various parts of the UI.
      */

--- a/src/workspace/workspaceExtension.ts
+++ b/src/workspace/workspaceExtension.ts
@@ -1,0 +1,44 @@
+import type { Events } from '../coreUtils/events';
+
+import type { ConnectionsMenuCommands } from '../widgets/connectionsMenu';
+import type { InstancesSearchCommands } from '../widgets/instancesSearch';
+import type { UnifiedSearchCommands } from '../widgets/unifiedSearch';
+import type { VisualAuthoringCommands } from '../widgets/visualAuthoring';
+
+/**
+ * Represents a workspace extension definition.
+ *
+ * Currently, an extension is defined as having a common event bus to
+ * communicate between different components.
+ */
+export class WorkspaceExtension<T> {
+    private __commandsMarker: Events<T> | undefined;
+
+    private constructor() {}
+
+    /**
+     * Defines a new workspace extension.
+     *
+     * **Experimental**: this feature will likely change in the future.
+     */
+    static define<T>() {
+        return new WorkspaceExtension<T>();
+    }
+}
+
+/**
+ * Event bus to connect {@link ConnectionMenu} to other components.
+ */
+export const ConnectionsMenuExtension = WorkspaceExtension.define<ConnectionsMenuCommands>();
+/**
+ * Event bus to connect {@link InstancesSearch} to other components.
+ */
+export const InstancesSearchExtension = WorkspaceExtension.define<InstancesSearchCommands>();
+/**
+ * Event bus to connect {@link UnifiedSearch} to other components.
+ */
+export const UnifiedSearchExtension = WorkspaceExtension.define<UnifiedSearchCommands>();
+/**
+ * Event bus to connect {@link VisualAuthoring} to other components.
+ */
+export const VisualAuthoringExtension = WorkspaceExtension.define<VisualAuthoringCommands>();


### PR DESCRIPTION
* Remove all commands-like props from components, e.g. `commands`, `connectionMenuCommands`, `instancesSearchCommands`, `searchCommands`.
* Triggering a command or listening for one from outside the component should be done by acquiring a commands object using `getCommandBus()` with the following built-in extensions: `ConnectionsMenuTopic`, `InstancesSearchTopic`, `UnifiedSearchTopic`, `VisualAuthoringTopic`.
* Custom extensions can be defined with `CommandBusTopic.define()` (currently only provides a common events bus between components).