### PR TITLE
Move synchronous (blocking) fallback layout into the separate entry point `/layout-sync`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   * Change `StandardTemplate` to a template object, expose its components as `StandardEntity` and `StandardEntityGroup`;
   * Change `ClassicTemplate` to a template object, expose its component as `ClassicEntity`.
 - Improve default routing for self (feedback) links with a single user-defined variable to have a basic loop instead of a straight line.
+- Reduce the size of the main package bundle by moving fallback synchronous (blocking) layout into the separate entry point `/layout-sync`:
+  * **[💥Breaking]** Make `defaultLayout` a required prop for a `Workspace`: if a bundled synchronous fallback (`blockingDefaultLayout()`) was used by default, now it is necessary to import it manually from `/layout-sync`;
+  * The recommended layout algorithm usage is as before via Web Workers with `defineLayoutWorker()` and `useWorker()`.
 - **[💥Breaking]** Replace explicit "commands" passing by common `WorkspaceContext.getCommandBus()`:
   * Remove all commands-like props from components, e.g. `commands`, `connectionMenuCommands`, `instancesSearchCommands`, `searchCommands`.
   * Triggering a command or listening for one from outside the component should be done by acquiring a commands object using `getCommandBus()` with the following built-in command bus topics: `ConnectionsMenuTopic`, `InstancesSearchTopic`, `UnifiedSearchTopic`, `VisualAuthoringTopic`.

--- a/package.json
+++ b/package.json
@@ -98,6 +98,10 @@
       "types": "./dist/typings/workspace.d.ts",
       "import": "./dist/workspace.js"
     },
+    "./layout-sync": {
+      "types": "./dist/typings/layout-sync.d.ts",
+      "default": "./dist/layout-sync.js"
+    },
     "./layout.worker": {
       "types": "./dist/typings/layout.worker.d.ts",
       "default": "./dist/layout.worker.js"

--- a/src/diagram/layoutShared.ts
+++ b/src/diagram/layoutShared.ts
@@ -267,10 +267,14 @@ export interface DefaultLayoutOptions {
  *
  * The algorithm used is force-directed layout from [cola.js](https://ialab.it.monash.edu/webcola/).
  *
- * This function is computationally expensive and should be used only as fallback
- * when other ways to compute diagram layout is not available.
- * The recommended way is to use web workers via `@reactodia/workspace/layout.worker`
- * and {@link useWorker Reactodia.useWorker()}`.
+ * **Warning**: this function is computationally expensive and should be used only as fallback
+ * when other ways to compute diagram layout is not available as the browser execution will
+ * freeze during the call for large diagrams.
+ * 
+ * The recommended way is to use web workers via
+ * {@link defineLayoutWorker Reactodia.defineLayoutWorker()} to import the worker from
+ * `@reactodia/workspace/layout.worker` and {@link useWorker Reactodia.useWorker()} to
+ * get a layout function from it.
  *
  * @category Geometry
  */

--- a/src/layout-sync.ts
+++ b/src/layout-sync.ts
@@ -1,0 +1,9 @@
+export {
+    DefaultLayoutOptions, blockingDefaultLayout,
+    ColaForceLayoutOptions, colaForceLayout,
+    ColaFlowLayoutOptions, colaFlowLayout,
+    PaddedLayoutState, layoutPadded,
+    PaddedBiasFreeLayoutState, layoutPaddedBiasFree,
+    colaRemoveOverlaps, getContentFittingBoxForLayout,
+    evaluateColaLayout
+} from './diagram/layoutShared';

--- a/src/layout.worker.ts
+++ b/src/layout.worker.ts
@@ -1,5 +1,4 @@
 import { connectWorker } from '@reactodia/worker-proxy/protocol';
-import * as cola from 'webcola';
 
 import type { LayoutGraph, LayoutState } from './diagram/layout';
 import {

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -78,12 +78,6 @@ export {
 } from './diagram/layout';
 export { DefaultLayouts, defineLayoutWorker } from './diagram/layoutDefault';
 export {
-    DefaultLayoutOptions, blockingDefaultLayout,
-    ColaForceLayoutOptions, colaForceLayout,
-    ColaFlowLayoutOptions, colaFlowLayout,
-    colaRemoveOverlaps, layoutPadded, layoutPaddedBiasFree, getContentFittingBoxForLayout,
-} from './diagram/layoutShared';
-export {
     LinkPath, LinkPathProps,
     LinkLabel, LinkLabelProps,
     LinkVertices, LinkVerticesProps,

--- a/src/workspace/workspace.tsx
+++ b/src/workspace/workspace.tsx
@@ -16,7 +16,6 @@ import { CommandHistory, InMemoryHistory } from '../diagram/history';
 import {
     CalculatedLayout, LayoutFunction, LayoutTypeProvider, calculateLayout, applyLayout,
 } from '../diagram/layout';
-import { blockingDefaultLayout } from '../diagram/layoutShared';
 import {
     DefaultTranslation, DefaultTranslationBundle, TranslationProvider,
 } from '../diagram/locale';
@@ -98,9 +97,13 @@ export interface WorkspaceProps {
     /**
      * Default function to compute diagram layout.
      *
-     * If not provided, uses {@link blockingDefaultLayout} as a synchronous fallback.
+     * It is recommended to get layout function from a background worker,
+     * e.g. with {@link defineDefaultLayouts} and {@link useWorker}.
+     *
+     * In cases when a worker is not available, it is possible to import and
+     * use {@link blockingDefaultLayout} as a synchronous fallback.
      */
-    defaultLayout?: LayoutFunction;
+    defaultLayout: LayoutFunction;
     /**
      * Handler for a request to navigate to a specific IRI.
      *
@@ -176,7 +179,7 @@ export class Workspace extends React.Component<WorkspaceProps> {
         const view = new SharedCanvasState({
             defaultElementTemplate: StandardTemplate,
             defaultLinkTemplate: DefaultLinkTemplate,
-            defaultLayout: defaultLayout ?? blockingDefaultLayout,
+            defaultLayout,
             renameLinkProvider,
         });
 
@@ -217,14 +220,6 @@ export class Workspace extends React.Component<WorkspaceProps> {
             ungroupSome: this.onUngroupSome,
             triggerWorkspaceEvent: onWorkspaceEvent,
         };
-
-        if (!defaultLayout) {
-            console.warn(
-                'Reactodia.Workspace: "defaultLayout" prop is not provided, using synchronous fallback ' +
-                'which may freeze the execution for large diagrams. It is recommended to use ' +
-                'layout worker via Reactodia.defineDefaultLayouts() and Reactodia.useWorker().'
-            );
-        }
     }
 
     /**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,7 @@ const mainConfig = {
   mode: 'none',
   entry: {
     'workspace': './src/workspace',
+    'layout-sync': './src/layout-sync',
   },
   output: {
     filename: '[name].js',


### PR DESCRIPTION
* Make `defaultLayout` a required prop for a `Workspace`;
* Now the main entry point bundle does not have any dependency on `webcola` so it won't be duplicated in recommended usage with Web Workers;