### PR TITLE
Support editing relation properties

### DIFF
--- a/src/data/validationProvider.ts
+++ b/src/data/validationProvider.ts
@@ -35,7 +35,7 @@ export type ValidationSeverity = 'info' | 'warning' | 'error';
 /**
  * Provides a strategy to validate changes to the data in the graph authoring mode.
  *
- * **Experimental**: this feature will likely change in the future.
+ * **Unstable**: this interface will likely change in the future.
  *
  * @category Core
  */

--- a/src/forms/propertiesInput.tsx
+++ b/src/forms/propertiesInput.tsx
@@ -1,0 +1,122 @@
+import * as React from 'react';
+
+import { useKeyedSyncStore } from '../coreUtils/keyedObserver';
+import { useTranslation } from '../coreUtils/i18n';
+
+import { PropertyTypeIri } from '../data/model';
+import * as Rdf from '../data/rdf/rdfModel';
+import type { MetadataPropertyShape, MetadataValueShape } from '../data/metadataProvider';
+
+import { subscribePropertyTypes } from '../editor/observedElement';
+import { WithFetchStatus } from '../editor/withFetchStatus';
+
+import { useWorkspace } from '../workspace/workspaceContext';
+
+import { TextPropertyInput } from './textPropertyInput';
+
+const FORM_CLASS = 'reactodia-form';
+
+export type PropertyUpdater = (previous: ReadonlyArray<Rdf.NamedNode | Rdf.Literal>) =>
+    ReadonlyArray<Rdf.NamedNode | Rdf.Literal>;
+
+const DEFAULT_VALUE_SHAPE: MetadataValueShape = {
+    termType: 'Literal',
+};
+export const DEFAULT_PROPERTY_SHAPE: MetadataPropertyShape = {
+    valueShape: DEFAULT_VALUE_SHAPE,
+};
+
+export function PropertiesInput(props: {
+    className?: string;
+    properties: ReadonlyMap<PropertyTypeIri, MetadataPropertyShape>;
+    languages: ReadonlyArray<string>;
+    data: { readonly [id: string]: ReadonlyArray<Rdf.NamedNode | Rdf.Literal> };
+    onChangeData: (property: PropertyTypeIri, updater: PropertyUpdater) => void;
+}) {
+    const {className, properties, languages, data, onChangeData} = props;
+    const {model, translation: t} = useWorkspace();
+
+    const extendedProperties = new Map(properties);
+    for (const propertyIri of Object.keys(data)) {
+        if (!extendedProperties.has(propertyIri)) {
+            extendedProperties.set(propertyIri, DEFAULT_PROPERTY_SHAPE);
+        }
+    }
+    const propertyIris = Array.from(extendedProperties.keys());
+    useKeyedSyncStore(subscribePropertyTypes, propertyIris, model);
+
+    if (propertyIris.length === 0) {
+        return null;
+    }
+
+    const labelledProperties = Array.from(extendedProperties, ([iri, shape]) => {
+        const property = model.getPropertyType(iri);
+        const values = Object.prototype.hasOwnProperty.call(data, iri) ? data[iri] : undefined;
+        return {
+            iri,
+            label: t.formatLabel(property?.data?.label, iri, model.language),
+            shape,
+            values: values ?? [],
+        };
+    });
+    labelledProperties.sort((a, b) => a.label.localeCompare(b.label));
+
+    return (
+        <div role='list'
+            className={className}>
+            {labelledProperties.map(({iri, label, shape, values}) =>
+                <Property key={iri}
+                    iri={iri}
+                    label={label}
+                    shape={shape}
+                    languages={languages}
+                    values={values}
+                    onChange={onChangeData}
+                    factory={model.factory}
+                />
+            )}
+        </div>
+    );
+}
+
+function Property(props: {
+    iri: PropertyTypeIri;
+    label: string;
+    shape: MetadataPropertyShape;
+    languages: ReadonlyArray<string>;
+    values: ReadonlyArray<Rdf.NamedNode | Rdf.Literal>;
+    onChange: (iri: PropertyTypeIri, updater: PropertyUpdater) => void;
+    factory: Rdf.DataFactory;
+}) {
+    const {iri, label, shape, languages, values, onChange, factory} = props;
+    const t = useTranslation();
+
+    const updateValues = React.useCallback((updater: PropertyUpdater) => {
+        onChange(iri, updater);
+    }, [iri, onChange]);
+
+    return (
+        <div className={`${FORM_CLASS}__row`}>
+            <label
+                title={t.text('visual_authoring.property.title', {
+                    property: label,
+                    propertyIri: iri,
+                })}>
+                <WithFetchStatus type='propertyType' target={iri}>
+                    <span>
+                        {t.text('visual_authoring.property.label', {
+                            property: label,
+                            propertyIri: iri,
+                        })}
+                    </span>
+                </WithFetchStatus>
+            </label>
+            <TextPropertyInput shape={shape}
+                languages={languages}
+                values={values}
+                updateValues={updateValues}
+                factory={factory}
+            />
+        </div>
+    );
+}

--- a/src/forms/textPropertyInput.tsx
+++ b/src/forms/textPropertyInput.tsx
@@ -7,10 +7,9 @@ import { useTranslation } from '../coreUtils/i18n';
 import * as Rdf from '../data/rdf/rdfModel';
 import type { MetadataPropertyShape, MetadataValueShape } from '../data/metadataProvider';
 
-const CLASS_NAME = 'reactodia-text-property-input';
+import type { PropertyUpdater } from './propertiesInput';
 
-export type PropertyUpdater = (previous: ReadonlyArray<Rdf.NamedNode | Rdf.Literal>) =>
-    ReadonlyArray<Rdf.NamedNode | Rdf.Literal>;
+const CLASS_NAME = 'reactodia-text-property-input';
 
 function TextPropertyInputInner(props: {
     shape: MetadataPropertyShape;

--- a/src/widgets/visualAuthoring/visualAuthoring.tsx
+++ b/src/widgets/visualAuthoring/visualAuthoring.tsx
@@ -231,8 +231,7 @@ export function VisualAuthoring(props: VisualAuthoringProps) {
                 target: link,
                 dialogType: BuiltinDialogType.editRelation,
                 style: {
-                    defaultSize: {width: 300, height: 180},
-                    resizableBy: 'x',
+                    defaultSize: {width: 340, height: 300},
                     caption,
                 },
                 content,

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -21,7 +21,7 @@ export { Debouncer, animateInterval } from './coreUtils/scheduler';
 export * from './data/model';
 export {
     MetadataProvider, MetadataCanConnect, MetadataCanModifyEntity, MetadataCanModifyRelation,
-    MetadataEntityShape, MetadataPropertyShape,
+    MetadataEntityShape, MetadataRelationShape, MetadataPropertyShape, EmptyMetadataProvider,
 } from './data/metadataProvider';
 export {
     ValidationProvider, ValidationEvent, ValidationResult, ValidatedElement, ValidatedLink,

--- a/styles/editor/_editEntityForm.scss
+++ b/styles/editor/_editEntityForm.scss
@@ -1,4 +1,3 @@
-@use "../mixin/icons" as *;
 @use "../theme/theme";
 
 .reactodia-edit-entity-form {

--- a/styles/editor/_editRelationForm.scss
+++ b/styles/editor/_editRelationForm.scss
@@ -1,0 +1,8 @@
+@use "../theme/theme";
+
+.reactodia-edit-relation-form {
+  &--loading {
+    align-items: center;
+    justify-content: center;
+  }
+}

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -12,6 +12,7 @@
 @forward "editor/authoringState";
 @forward "editor/dragEditLayer";
 @forward "editor/editEntityForm";
+@forward "editor/editRelationForm";
 @forward "editor/elementSelector";
 @forward "editor/loadingWidget";
 @forward "editor/textPropertyInput";


### PR DESCRIPTION
* Add `MetadataProvider.getRelationShape()` interface method to get editor metadata for relation properties;
* Allow to return `canEdit: true` from `MetadataProvider.canModifyRelation()` to display relation properties editor;
* Export `EmptyMetadataProvider` as a stable base class to extend from when implementing custom metadata providers.