### PR TITLE
Display inline actions to edit or delete entities

### DIFF
--- a/i18n/i18n.schema.json
+++ b/i18n/i18n.schema.json
@@ -12,19 +12,22 @@
       "$ref": "#/$defs/Group",
       "additionalProperties": false,
       "properties": {
-        "discard.label": { "$ref": "#/$defs/Value" },
+        "entity_action_delete.label": { "$ref": "#/$defs/Value" },
+        "entity_action_delete.title": { "$ref": "#/$defs/Value" },
+        "entity_action_delete.title_disabled": { "$ref": "#/$defs/Value" },
+        "entity_action_discard.label": { "$ref": "#/$defs/Value" },
+        "entity_action_discard.title": { "$ref": "#/$defs/Value" },
+        "entity_action_edit.label": { "$ref": "#/$defs/Value" },
+        "entity_action_edit.title": { "$ref": "#/$defs/Value" },
+        "entity_action_edit.title_disabled": { "$ref": "#/$defs/Value" },
         "entity_add.label": { "$ref": "#/$defs/Value" },
-        "entity_add_revert.title": { "$ref": "#/$defs/Value" },
         "entity_change.label": { "$ref": "#/$defs/Value" },
-        "entity_change_revert.title": { "$ref": "#/$defs/Value" },
         "entity_delete.label": { "$ref": "#/$defs/Value" },
-        "entity_delete_revert.title": { "$ref": "#/$defs/Value" },
+        "relation_action_discard.label": { "$ref": "#/$defs/Value" },
+        "relation_action_discard.title": { "$ref": "#/$defs/Value" },
         "relation_add.label": { "$ref": "#/$defs/Value" },
-        "relation_add_revert.title": { "$ref": "#/$defs/Value" },
         "relation_change.label": { "$ref": "#/$defs/Value" },
-        "relation_change_revert.title": { "$ref": "#/$defs/Value" },
-        "relation_delete.label": { "$ref": "#/$defs/Value" },
-        "relation_delete_revert.title": { "$ref": "#/$defs/Value" }
+        "relation_delete.label": { "$ref": "#/$defs/Value" }
       }
     },
     "classic_workspace": {

--- a/i18n/translations/en.reactodia-translation.json
+++ b/i18n/translations/en.reactodia-translation.json
@@ -1,19 +1,22 @@
 {
   "$schema": "../i18n.schema.json",
   "authoring_state": {
-    "discard.label": "cancel",
+    "entity_action_delete.label": "delete",
+    "entity_action_delete.title": "Delete entity",
+    "entity_action_delete.title_disabled": "Cannot delete the entity",
+    "entity_action_discard.label": "cancel",
+    "entity_action_discard.title": "Discard all changes to the entity",
+    "entity_action_edit.label": "edit",
+    "entity_action_edit.title": "Edit entity",
+    "entity_action_edit.title_disabled": "Cannot edit the entity",
     "entity_add.label": "New",
-    "entity_add_revert.title": "Revert creation of the entity",
     "entity_change.label": "Change",
-    "entity_change_revert.title": "Revert all changes in properties of the entity",
     "entity_delete.label": "Delete",
-    "entity_delete_revert.title": "Revert deletion of the entity",
+    "relation_action_discard.label": "cancel",
+    "relation_action_discard.title": "Discard all changes to the relation",
     "relation_add.label": "New",
-    "relation_add_revert.title": "Revert creation of the relation",
     "relation_change.label": "Change",
-    "relation_change_revert.title": "Revert all changes in properties of the relation",
-    "relation_delete.label": "Delete",
-    "relation_delete_revert.title": "Revert deletion of the relation"
+    "relation_delete.label": "Delete"
   },
   "classic_workspace": {
     "class_tree.heading": "Classes",

--- a/src/widgets/visualAuthoring/authoredRelationOverlay.tsx
+++ b/src/widgets/visualAuthoring/authoredRelationOverlay.tsx
@@ -16,7 +16,7 @@ import { RenderingLayer } from '../../diagram/renderingState';
 import { Link } from '../../diagram/elements';
 import { HtmlSpinner } from '../../diagram/spinner';
 
-import { AuthoringState } from '../../editor/authoringState';
+import { AuthoredRelation, AuthoringState } from '../../editor/authoringState';
 import { RelationLink } from '../../editor/dataElements';
 import { getMaxSeverity } from '../../editor/validation';
 
@@ -127,7 +127,7 @@ class LinkStateWidgetInner extends React.Component<AuthoredRelationOverlayInnerP
     }
 
     private renderLinkStateLabels() {
-        const {workspace: {model, editor, translation: t}} = this.props;
+        const {workspace: {model, editor}} = this.props;
 
         const rendered: React.ReactElement[] = [];
         for (const link of model.links) {
@@ -135,39 +135,8 @@ class LinkStateWidgetInner extends React.Component<AuthoredRelationOverlayInnerP
                 continue;
             }
 
-            let renderedState: React.ReactElement | null = null;
             const state = editor.authoringState.links.get(link.data);
-            if (state) {
-                let statusText: string;
-                let title: string;
-
-                switch (state.type) {
-                    case 'relationAdd': {
-                        statusText = t.text('authoring_state.relation_add.label');
-                        title = t.text('authoring_state.relation_add_revert.title');
-                        break;
-                    }
-                    case 'relationChange': {
-                        statusText = t.text('authoring_state.relation_change.label');
-                        title = t.text('authoring_state.relation_change_revert.title');
-                        break;
-                    }
-                    case 'relationDelete': {
-                        statusText = t.text('authoring_state.relation_delete.label');
-                        title = t.text('authoring_state.relation_delete_revert.title');
-                        break;
-                    }
-                }
-
-                renderedState = (
-                    <span>
-                        <span className={`${CLASS_NAME}__state-label`}>{statusText}</span>
-                        [<span className={`${CLASS_NAME}__state-cancel`}
-                            onClick={() => editor.discardChange(state)}
-                            title={title}>{t.text('authoring_state.discard.label')}</span>]
-                    </span>
-                );
-            }
+            const renderedState = this.renderLinkStatus(state);
 
             const renderedValidations = this.renderLinkValidations(link.data);
             if (renderedState || renderedValidations) {
@@ -191,6 +160,32 @@ class LinkStateWidgetInner extends React.Component<AuthoredRelationOverlayInnerP
         }
 
         return rendered;
+    }
+
+    private renderLinkStatus(state: AuthoredRelation | undefined) {
+        const {workspace: {editor, translation: t}} = this.props;
+
+        if (!state) {
+            return null;
+        }
+
+        return (
+            <>
+                <span className={`${CLASS_NAME}__state-label`}>
+                    {(
+                        state.type === 'relationAdd' ? t.text('authoring_state.relation_add.label') :
+                        state.type === 'relationChange' ? t.text('authoring_state.relation_change.label') :
+                        state.type === 'relationDelete' ? t.text('authoring_state.relation_delete.label') :
+                        null
+                    )}
+                </span>
+                <span className={`${CLASS_NAME}__action ${CLASS_NAME}__action-discard`}
+                    onClick={() => editor.discardChange(state)}
+                    title={t.text('authoring_state.relation_action_discard.title')}>
+                    {t.text('authoring_state.relation_action_discard.label')}
+                </span>
+            </>
+        );
     }
 
     private renderLinkStateHighlighting() {

--- a/src/widgets/visualAuthoring/visualAuthoring.tsx
+++ b/src/widgets/visualAuthoring/visualAuthoring.tsx
@@ -41,6 +41,12 @@ export interface VisualAuthoringProps {
      * Overrides default input for a specific entity or relation property.
      */
     inputResolver?: PropertyInputOrDefaultResolver;
+    /**
+     * Whether to display inline authoring actions (edit, delete) on entity elements.
+     *
+     * @default true
+     */
+    inlineEntityActions?: boolean;
 }
 
 /**
@@ -100,7 +106,7 @@ export interface VisualAuthoringCommands {
  * @category Components
  */
 export function VisualAuthoring(props: VisualAuthoringProps) {
-    const {propertyEditor, inputResolver} = props;
+    const {propertyEditor, inputResolver, inlineEntityActions = true} = props;
     const {model, view, editor, overlay, translation: t, getCommandBus} = useWorkspace();
 
     React.useLayoutEffect(() => {
@@ -116,6 +122,7 @@ export function VisualAuthoring(props: VisualAuthoringProps) {
                 return (
                     <AuthoredEntityDecorator target={element}
                         position={element.position}
+                        inlineActions={inlineEntityActions}
                     />
                 );
             }

--- a/styles/editor/_authoringState.scss
+++ b/styles/editor/_authoringState.scss
@@ -1,3 +1,4 @@
+@use "../mixin/icons" as *;
 @use "../theme/theme";
 
 .reactodia-authoring-state {
@@ -53,10 +54,6 @@
     stroke: theme.$color-primary;
   }
 
-  &__item-validation:not(:first-child) {
-    margin-left: 5px;
-  }
-
   &__item-validation {
     align-self: flex-end;
     display: flex;
@@ -90,15 +87,6 @@
 
   &__state-label {
     font-weight: bold;
-    margin-right: 5px;
-  }
-
-  &__state-cancel {
-    color: theme.$color-primary;
-    cursor: pointer;
-    &:hover {
-      text-decoration: underline;
-    }
   }
 
   &__state-indicator {
@@ -112,9 +100,46 @@
     white-space: nowrap;
     display: flex;
     align-items: center;
+    gap: theme.$spacing-horizontal;
     bottom: 0;
     background: theme.$canvas-underlay-color;
     border-radius: 2px;
     padding: 1px;
+    height: 22px;
+  }
+
+  &__actions {
+    display: flex;
+    gap: theme.$spacing-horizontal;
+  }
+
+  &__action {
+    background: none;
+    border: 0 none;
+    padding: 0;
+    cursor: pointer;
+
+    opacity: 0.5;
+    transition: opacity theme.$transition-duration;
+    &:hover {
+      opacity: 1;
+    }
+
+    &[disabled] {
+      cursor: not-allowed;
+      opacity: 0.2;
+    }
+  }
+
+  &__action-edit {
+    @include codicon-button("edit");
+  }
+
+  &__action-delete {
+    @include codicon-button("trash");
+  }
+
+  &__action-discard {
+    @include codicon-button("discard");
   }
 }


### PR DESCRIPTION
* Add new prop `inlineEntityActions` (defaults to `true`) to display entity actions inline at the top of each entity;
* Always display validation state for an entities and relations even when the target does not have any authoring changes;
* Improve the look for "cancel" (discard) action on entities and relations;
* Change translation keys in `authoring_state` group for discarding changes.