### PR TITLE
Fix warnings and issues in React v19 strict development mode

### DIFF
--- a/src/forms/elementTypeSelector.tsx
+++ b/src/forms/elementTypeSelector.tsx
@@ -67,7 +67,7 @@ const FORM_CLASS = 'reactodia-form';
 
 export class ElementTypeSelectorInner extends React.Component<ElementTypeSelectorInnerProps, State> {
     private readonly listener = new EventObserver();
-    private readonly cancellation = new AbortController();
+    private fetchTypesCancellation = new AbortController();
     private filterCancellation = new AbortController();
     private loadingItemCancellation = new AbortController();
 
@@ -107,7 +107,7 @@ export class ElementTypeSelectorInner extends React.Component<ElementTypeSelecto
 
     componentWillUnmount() {
         this.listener.stopListening();
-        this.cancellation.abort();
+        this.fetchTypesCancellation.abort();
         this.filterCancellation.abort();
         this.loadingItemCancellation.abort();
     }
@@ -119,14 +119,19 @@ export class ElementTypeSelectorInner extends React.Component<ElementTypeSelecto
         if (!metadataProvider) {
             return;
         }
+
+        this.fetchTypesCancellation.abort();
+        this.fetchTypesCancellation = new AbortController();
+        const signal = this.fetchTypesCancellation.signal;
+
         const connections = await mapAbortedToNull(
             metadataProvider.canConnect(
                 source,
                 undefined,
                 undefined,
-                {signal: this.cancellation.signal}
+                {signal}
             ),
-            this.cancellation.signal
+            signal
         );
         if (connections === null) {
             return;


### PR DESCRIPTION
* Fix "`flushSync()` called from lifecycle method" warning caused by discarding layout from dispose callback in `useEffect()`;
* Fix inconsistencies due to mount > unmount > mount sequence in strict mode for development React bundle.