### PR TITLE
Bundle WebCola in `layout.worker` bundle to avoid build issues due to mixed module imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reactodia/workspace",
-  "version": "0.29.1",
+  "version": "0.30.0-next",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@reactodia/workspace",
-      "version": "0.29.1",
+      "version": "0.30.0-next",
       "license": "LGPL-2.1-or-later",
       "dependencies": {
         "@reactodia/hashmap": "^0.1.0",
@@ -43,6 +43,7 @@
         "rimraf": "^6.0.1",
         "sass": "^1.85.1",
         "sass-loader": "^16.0.5",
+        "source-map-loader": "^5.0.0",
         "style-loader": "^4.0.0",
         "ts-loader": "^9.5.2",
         "tslib": "^2.8.1",
@@ -8375,6 +8376,40 @@
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-loader": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-5.0.0.tgz",
+      "integrity": "sha512-k2Dur7CbSLcAH73sBcIkV5xjPV4SzqO1NJ7+XaQl8if3VODDUj3FNchNGpqgJSKbvUfJuhVdv8K2Eu8/TNl2eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.72.1"
+      }
+    },
+    "node_modules/source-map-loader/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactodia/workspace",
-  "version": "0.29.1",
+  "version": "0.30.0-next",
   "description": "Reactodia Workspace -- library for visual interaction with graphs in a form of a diagram.",
   "repository": {
     "type": "git",
@@ -76,6 +76,7 @@
     "rimraf": "^6.0.1",
     "sass": "^1.85.1",
     "sass-loader": "^16.0.5",
+    "source-map-loader": "^5.0.0",
     "style-loader": "^4.0.0",
     "ts-loader": "^9.5.2",
     "tslib": "^2.8.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,7 +60,6 @@ const mainConfig = {
     'react',
     'react/jsx-runtime',
     'react-dom',
-    'webcola',
   ],
   devtool: 'source-map',
 };
@@ -88,7 +87,13 @@ const workerConfig = {
       {
         test: /\.([cm]?ts|tsx)$/,
         loader: 'ts-loader',
-      }
+      },
+      // Load source maps from bundled WebCola
+      {
+        test: /\.js$/,
+        enforce: 'pre',
+        loader: 'source-map-loader',
+      },
     ],
   },
   externals: mainConfig.externals,


### PR DESCRIPTION
* Bundle WebCola into `@reactodia/workspace/layout.worker` bundle to avoid build issues when importing the library with Vite due to CommonJs-style imports in WebCola (causes mixed-style module structure with internal ES-imports).