### PR TITLE
Follow-up on property inputs in forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Export `EmptyMetadataProvider` as a stable base class to extend from when implementing custom metadata providers.
 - Provide gradual customization options for the built-in entity and relation property editor:
   * Expose ability to customize property input in authoring forms with `inputResolver` option for `VisualAuthoring` component;
-  * Export built-in inputs `PropertyInputList` and `PropertyInputText`, as well as `PropertyInputSingleProps` and `PropertyInputMultiProps` props interfaces to implement custom property inputs.
+  * Export built-in inputs `FormInputList` and `FormInputText`, as well as `FormInputSingleProps` and `FormInputMultiProps` props interfaces to implement custom property inputs.
 
 #### 🔧 Maintenance
 - Make library compatible with [React v19](https://react.dev/blog/2024/12/05/react-19), while continuing support for v17 and v18.

--- a/examples/graphAuthoring.tsx
+++ b/examples/graphAuthoring.tsx
@@ -62,9 +62,12 @@ function GraphAuthoringExample() {
             renameLinkProvider={renameLinkProvider}>
             <Reactodia.DefaultWorkspace
                 menu={<ExampleToolbarMenu />}
+                canvas={{
+                    elementTemplateResolver: () => Reactodia.RoundTemplate,
+                }}
                 visualAuthoring={{
                     inputResolver: (property, inputProps) => property === 'http://www.w3.org/2000/01/rdf-schema#comment'
-                        ? <Reactodia.PropertyInputList {...inputProps} valueInput={MultilineTextInput} />
+                        ? <Reactodia.FormInputList {...inputProps} valueInput={MultilineTextInput} />
                         : undefined,
                 }}
             />
@@ -78,8 +81,8 @@ class RenameSubclassOfProvider extends Reactodia.RenameLinkToLinkStateProvider {
     }
 }
 
-function MultilineTextInput(props: Reactodia.PropertyInputSingleProps) {
-    return <Reactodia.PropertyInputText {...props} multiline />;
+function MultilineTextInput(props: Reactodia.FormInputSingleProps) {
+    return <Reactodia.FormInputText {...props} multiline />;
 }
 
 mountOnLoad(<GraphAuthoringExample />);

--- a/examples/resources/exampleMetadata.ts
+++ b/examples/resources/exampleMetadata.ts
@@ -160,9 +160,15 @@ export class ExampleMetadataProvider extends Reactodia.EmptyMetadataProvider {
             });
             properties.set(rdfs.seeAlso, {
                 valueShape: {termType: 'NamedNode'},
+                maxCount: 1,
             });
         }
-        return {properties};
+        return {
+            extraProperty: {
+                valueShape: {termType: 'Literal'},
+            },
+            properties,
+        };
     }
 
     async getRelationShape(

--- a/src/data/metadataProvider.ts
+++ b/src/data/metadataProvider.ts
@@ -83,15 +83,32 @@ export interface MetadataCanModifyRelation {
 }
 
 export interface MetadataEntityShape {
+    readonly extraProperty?: MetadataPropertyShape;
     readonly properties: ReadonlyMap<PropertyTypeIri, MetadataPropertyShape>;
 }
 
 export interface MetadataRelationShape {
+    readonly extraProperty?: MetadataPropertyShape;
     readonly properties: ReadonlyMap<PropertyTypeIri, MetadataPropertyShape>;
 }
 
 export interface MetadataPropertyShape {
+    /**
+     * RDF term shape for the property.
+     */
     readonly valueShape: MetadataValueShape;
+    /**
+     * Minimum number of values for the property.
+     *
+     * @default 0
+     */
+    readonly minCount?: number;
+    /**
+     * Maximum number of values for the property (inclusive).
+     *
+     * @default Infinity
+     */
+    readonly maxCount?: number;
 }
 
 export type MetadataValueShape =

--- a/src/forms/input/formInputText.tsx
+++ b/src/forms/input/formInputText.tsx
@@ -5,16 +5,16 @@ import { useTranslation } from '../../coreUtils/i18n';
 
 import * as Rdf from '../../data/rdf/rdfModel';
 
-import { type PropertyInputSingleProps } from './inputCommon';
+import { type FormInputSingleProps } from './inputCommon';
 
 const CLASS_NAME = 'reactodia-property-input-text';
 
 /**
- * Props for {@link PropertyInputText} component.
+ * Props for {@link FormInputText} component.
  *
- * @see {@link PropertyInputText}
+ * @see {@link FormInputText}
  */
-export interface PropertyInputTextProps extends PropertyInputSingleProps {
+export interface FormInputTextProps extends FormInputSingleProps {
     /**
      * Whether to use multiline `textarea` to display and edit the text value.
      *
@@ -22,7 +22,7 @@ export interface PropertyInputTextProps extends PropertyInputSingleProps {
      */
     multiline?: boolean;
     /**
-     * Placeholder text for the property input.
+     * Placeholder text for the form input.
      *
      * @default "Property value"
      */
@@ -30,13 +30,15 @@ export interface PropertyInputTextProps extends PropertyInputSingleProps {
 }
 
 /**
- * Property input to edit a single value as a plain string.
+ * Form input to edit a single value as a plain string.
  *
  * If specified value shape has `rdf:langString` or `xsd:string` datatype,
  * a language selector with languages from {@link MetadataProvider.getLiteralLanguages}
  * will be displayed as well.
+ *
+ * **Unstable**: this component will likely change in the future.
  */
-export function PropertyInputText(props: PropertyInputTextProps) {
+export function FormInputText(props: FormInputTextProps) {
     const {
         shape: {valueShape}, languages, value: term, setValue, factory,
         multiline, placeholder,

--- a/src/forms/input/inputCommon.tsx
+++ b/src/forms/input/inputCommon.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import * as Rdf from '../../data/rdf/rdfModel';
 import { PropertyTypeIri } from '../../data/model';
 
-import type { MetadataPropertyShape, MetadataValueShape } from '../../data/metadataProvider';
+import type { MetadataPropertyShape } from '../../data/metadataProvider';
 
 /**
  * Resolves an input component to edit a specific entity or relation property.
@@ -14,15 +14,15 @@ import type { MetadataPropertyShape, MetadataValueShape } from '../../data/metad
  *
  * @see {@link VisualAuthoring.inputResolver}
  */
-export type PropertyInputOrDefaultResolver = (property: PropertyTypeIri, inputProps: PropertyInputMultiProps) =>
+export type FormInputOrDefaultResolver = (property: PropertyTypeIri, inputProps: FormInputMultiProps) =>
     React.ReactElement | undefined | null;
 
 /**
  * Props for a property input accepting a single value to edit.
  *
- * @see {@link PropertyInputOrDefaultResolver}
+ * @see {@link FormInputOrDefaultResolver}
  */
-export interface PropertyInputSingleProps {
+export interface FormInputSingleProps {
     /**
      * Property shape metadata.
      */
@@ -50,9 +50,9 @@ export interface PropertyInputSingleProps {
 /**
  * Props for a property input accepting multiple values to edit.
  *
- * @see {@link PropertyInputOrDefaultResolver}
+ * @see {@link FormInputOrDefaultResolver}
  */
-export interface PropertyInputMultiProps {
+export interface FormInputMultiProps {
     /**
      * Property shape metadata.
      */
@@ -70,7 +70,7 @@ export interface PropertyInputMultiProps {
     /**
      * Sets the current list (or set) of values for the edited property.
      */
-    updateValues: (updater: PropertyInputMultiUpdater) => void;
+    updateValues: (updater: FormInputMultiUpdater) => void;
     /**
      * RDF/JS-compatible term factory to create RDF terms.
      */
@@ -80,15 +80,7 @@ export interface PropertyInputMultiProps {
 /**
  * Pure function to update a previous set of property values into a new one.
  *
- * @see {@link PropertyInputMultiProps.updateValues}
+ * @see {@link FormInputMultiProps.updateValues}
  */
-export type PropertyInputMultiUpdater = (previous: ReadonlyArray<Rdf.NamedNode | Rdf.Literal>) =>
+export type FormInputMultiUpdater = (previous: ReadonlyArray<Rdf.NamedNode | Rdf.Literal>) =>
     ReadonlyArray<Rdf.NamedNode | Rdf.Literal>;
-
-const DEFAULT_VALUE_SHAPE: MetadataValueShape = {
-    termType: 'Literal',
-};
-
-export const DEFAULT_PROPERTY_SHAPE: MetadataPropertyShape = {
-    valueShape: DEFAULT_VALUE_SHAPE,
-};

--- a/src/widgets/visualAuthoring/visualAuthoring.tsx
+++ b/src/widgets/visualAuthoring/visualAuthoring.tsx
@@ -12,9 +12,9 @@ import { AuthoringState } from '../../editor/authoringState';
 import { BuiltinDialogType } from '../../editor/builtinDialogType';
 import { EntityElement, RelationLink } from '../../editor/dataElements';
 
-import type { PropertyInputOrDefaultResolver } from '../../forms/input/inputCommon';
-import { PropertyInputText } from '../../forms/input/propertyInputText';
-import { PropertyInputList } from '../../forms/input/propertyInputList';
+import { FormInputList } from '../../forms/input/formInputList';
+import { FormInputText } from '../../forms/input/formInputText';
+import type { FormInputOrDefaultResolver } from '../../forms/input/inputCommon';
 import { EditRelationForm } from '../../forms/editRelationForm';
 import { EditEntityForm } from '../../forms/editEntityForm';
 import { FindOrCreateEntityForm } from '../../forms/findOrCreateEntityForm';
@@ -39,8 +39,10 @@ export interface VisualAuthoringProps {
     propertyEditor?: PropertyEditor;
     /**
      * Overrides default input for a specific entity or relation property.
+     *
+     * **Unstable**: this feature will likely change in the future.
      */
-    inputResolver?: PropertyInputOrDefaultResolver;
+    inputResolver?: FormInputOrDefaultResolver;
     /**
      * Whether to display inline authoring actions (edit, delete) on entity elements.
      *
@@ -183,7 +185,7 @@ export function VisualAuthoring(props: VisualAuthoringProps) {
                     onCancel={onCancel}
                     resolveInput={(property, inputProps) => {
                         const input = inputResolver?.(property, inputProps);
-                        return input ?? <PropertyInputList {...inputProps} valueInput={PropertyInputText} />;
+                        return input ?? <FormInputList {...inputProps} valueInput={FormInputText} />;
                     }}
                 />
             );
@@ -242,7 +244,7 @@ export function VisualAuthoring(props: VisualAuthoringProps) {
                     onCancel={() => overlay.hideDialog()}
                     resolveInput={(property, inputProps) => {
                         const input = inputResolver?.(property, inputProps);
-                        return input ?? <PropertyInputList {...inputProps} valueInput={PropertyInputText} />;
+                        return input ?? <FormInputList {...inputProps} valueInput={FormInputText} />;
                     }}
                 />
             );

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -129,11 +129,11 @@ export { ValidationState, ElementValidation, LinkValidation } from './editor/val
 export { WithFetchStatus, WithFetchStatusProps } from './editor/withFetchStatus';
 
 export type {
-    PropertyInputSingleProps, PropertyInputMultiProps, PropertyInputMultiUpdater,
-    PropertyInputOrDefaultResolver,
+    FormInputSingleProps, FormInputMultiProps, FormInputMultiUpdater,
+    FormInputOrDefaultResolver,
 } from './forms/input/inputCommon';
-export { PropertyInputList, type PropertyInputListProps } from './forms/input/propertyInputList';
-export { PropertyInputText, type PropertyInputTextProps } from './forms/input/propertyInputText';
+export { FormInputList, type FormInputListProps } from './forms/input/formInputList';
+export { FormInputText, type FormInputTextProps } from './forms/input/formInputText';
 
 export {
     SerializedDiagram, SerializedLayout, SerializedLinkOptions,


### PR DESCRIPTION
* Rename inputs from `PropertyInput*` to `FormInput*`;
* Support cardinality (`minCount` and `maxCount` in property shapes);
* Use extra properties without a shape only when an explicit `extraProperty` shape is provided from `MetadataProvider.getEntityShape()` or `MetadataProvider.getRelationShape()`;
* Allow to override entity IRI input with special property `urn:reactodia:entityIri`.