### PR TITLE
Use separate HTML paper layer for link labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   * Improve the style for "cancel" (discard) action on entities and relations to make it consistent with other inline actions.
 - Add `ElementDecoration` component to display additional decorations over canvas elements either from the template itself or from outside the element:
   * Element decorations are not included in the computed element bounds but are exported with the canvas unless explicitly marked with `data-reactodia-no-export` attribute (as with other canvas elements);
+- **[💥Breaking]** Use separate HTML paper layer to display `LinkLabel` components instead of an SVG canvas, which allows to use CSS for layout, backgrounds and improves rendering performance:
+  * `textClass`, `textStyle`, `rectClass` and `rectStyle` are replaced by `className` and `style` props;
+  * CSS should use HTML styling properties instead of SVG variants, e.g. `color` and `background-color` instead of `stroke` and `fill`;
+  * Label content should be placed directly as children to the component instead of using `content` prop.
 - Select entity label and image using `DataLocaleProvider` based on its properties:
   * **[💥Breaking]** Remove `ElementModel.{label, image}` properties and instead use `DataDiagramModel.locale` methods to select them based on `ElementModel.properties` instead;
   * Allow to override data locale provider (default is `DefaultDataLocaleProvider`) by passing `locale` option to `model.importLayout()` or `model.createNewDiagram()`;

--- a/examples/stressTest.tsx
+++ b/examples/stressTest.tsx
@@ -13,7 +13,11 @@ function StressTestExample() {
         const {model, view} = context;
 
         const dataProvider = new Reactodia.RdfDataProvider();
-        const [graphData, nodes] = createLayout(500, 2, dataProvider.factory);
+        const [graphData, nodes] = createLayout(dataProvider.factory, {
+            nodeCount: 500,
+            edgesPerNode: 2,
+            propertyPerEdge: 1,
+        });
         dataProvider.addGraph(graphData);
 
         const diagram = tryLoadLayoutFromLocalStorage();
@@ -67,11 +71,12 @@ function StressTestExample() {
     );
 }
 
-function createLayout(
-    nodeCount: number,
-    edgesPerNode: number,
-    factory: Reactodia.Rdf.DataFactory
-): [Reactodia.Rdf.Quad[], Reactodia.ElementIri[]] {
+function createLayout(factory: Reactodia.Rdf.DataFactory, options: {
+    nodeCount: number;
+    edgesPerNode: number;
+    propertyPerEdge: number;
+}): [Reactodia.Rdf.Quad[], Reactodia.ElementIri[]] {
+    const {nodeCount, edgesPerNode, propertyPerEdge} = options;
     const rdfType = factory.namedNode(Reactodia.rdf.type);
     const rdfsLabel = factory.namedNode(Reactodia.rdfs.label);
     const nodeType = factory.namedNode('urn:test:Node');
@@ -94,7 +99,13 @@ function createLayout(
         for (let j = 0; j < edgesPerNode; j++) {
             const target = i - j - 1;
             if (target >= 0) {
-                quads.push(factory.quad(iri, linkType, makeNodeIri(target)));
+                const link = factory.quad(iri, linkType, makeNodeIri(target));
+                quads.push(link);
+                for (let k = 0; k < propertyPerEdge; k++) {
+                    quads.push(factory.quad(
+                        link, factory.namedNode(`urn:test:property-${k}`), factory.literal(String(k))
+                    ));
+                };
             }
         }
     }

--- a/examples/styleCustomization.tsx
+++ b/examples/styleCustomization.tsx
@@ -160,7 +160,7 @@ const DoubleArrowLinkTemplate: Reactodia.LinkTemplate = {
         <Reactodia.DefaultLink {...props}
             pathProps={{stroke: '#747da8', strokeWidth: 2}}
             primaryLabelProps={{
-                textStyle: {fill: '#747da8'},
+                style: {color: '#747da8'},
             }}
         />
     ),

--- a/src/diagram/paperArea.tsx
+++ b/src/diagram/paperArea.tsx
@@ -18,7 +18,7 @@ import { ElementLayer } from './elementLayer';
 import {
     Vector, Rect, computePolyline, findNearestSegmentIndex, getContentFittingBox,
 } from './geometry';
-import { LinkLayer, LinkMarkers } from './linkLayer';
+import { LinkLabelLayer, LinkLayer, LinkMarkers } from './linkLayer';
 import { DiagramModel } from './model';
 import { CommandBatch } from './history';
 import { Paper, PaperTransform, SvgPaperLayer } from './paper';
@@ -99,6 +99,7 @@ export class PaperArea extends React.Component<PaperAreaProps, State> implements
     private area!: HTMLDivElement;
     private readonly rootRef = React.createRef<HTMLDivElement>();
     private readonly linkLayerRef = React.createRef<SVGSVGElement>();
+    private readonly labelLayerRef = React.createRef<HTMLDivElement>();
     private readonly elementLayerRef = React.createRef<HTMLDivElement>();
 
     private readonly pageSize = {x: 1500, y: 800};
@@ -221,6 +222,10 @@ export class PaperArea extends React.Component<PaperAreaProps, State> implements
                                     links={model.links}
                                 />
                             </SvgPaperLayer>
+                            <LinkLabelLayer renderingState={renderingState}
+                                paperTransform={paperTransform}
+                                layerRef={this.labelLayerRef}
+                            />
                             <div className={`${CLASS_NAME}__widgets`}
                                 onPointerDown={this.onWidgetsPointerDown}>
                                 {renderedWidgets
@@ -868,9 +873,10 @@ export class PaperArea extends React.Component<PaperAreaProps, State> implements
             removeByCssSelectors = [],
         } = baseOptions;
         const linkLayer = this.linkLayerRef.current;
+        const labelLayer = this.labelLayerRef.current;
         const elementLayer = this.elementLayerRef.current;
-        if (!(linkLayer && elementLayer)) {
-            throw new Error('Cannot find element and link layers to export');
+        if (!(linkLayer && labelLayer && elementLayer)) {
+            throw new Error('Cannot find element, link or label layers to export');
         }
         return {
             colorSchemeApi,
@@ -878,6 +884,7 @@ export class PaperArea extends React.Component<PaperAreaProps, State> implements
             contentBox: this.getContentFittingBox(),
             layers: [
                 linkLayer,
+                labelLayer,
                 elementLayer,
             ],
             preserveDimensions: true,

--- a/src/diagram/renderingState.ts
+++ b/src/diagram/renderingState.ts
@@ -185,6 +185,7 @@ export class MutableRenderingState implements RenderingState {
     private readonly decorationContainers = new WeakMap<Element | Link, HTMLDivElement>();
 
     private readonly elementSizes = new WeakMap<Element, Size>();
+    private readonly linkLabelContainer = document.createElement('div');
     private readonly linkLabelBounds = new WeakMap<Link, Rect>();
 
     private readonly linkTypeIndex = new Map<LinkTypeIri, number>();
@@ -283,6 +284,23 @@ export class MutableRenderingState implements RenderingState {
         }
     }
 
+    attachLinkLabelContainer(parent: HTMLElement | null): void {
+        if (parent) {
+            if (this.linkLabelContainer.parentElement) {
+                throw new Error('Cannot attach link label container to multiple parents');
+            }
+            parent.appendChild(this.linkLabelContainer);
+        } else {
+            if (this.linkLabelContainer.parentElement) {
+                this.linkLabelContainer.parentElement.removeChild(this.linkLabelContainer);
+            }
+        }
+    }
+
+    getLinkLabelContainer(): HTMLElement {
+        return this.linkLabelContainer;
+    }
+
     getLinkLabelBounds(link: Link): Rect | undefined {
         return this.linkLabelBounds.get(link);
     }
@@ -291,10 +309,7 @@ export class MutableRenderingState implements RenderingState {
         const previous = this.linkLabelBounds.get(link);
         const sameBounds = !previous && !bounds || (
             previous && bounds &&
-            previous.x === bounds.x &&
-            previous.y === bounds.y &&
-            previous.width === bounds.width &&
-            previous.height === bounds.height
+            Rect.equals(previous, bounds)
         );
         if (!sameBounds) {
             if (bounds) {

--- a/src/legacy-styles.tsx
+++ b/src/legacy-styles.tsx
@@ -74,13 +74,13 @@ export function makeLinkStyleShowIri(Reactodia: typeof import('./workspace')): L
                     <Reactodia.LinkLabel link={props.link}
                         position={props.getPathPosition(0.5)}
                         line={1}
-                        textStyle={{
-                            fill: 'gray',
+                        style={{
+                            color: 'gray',
                             fontSize: 12,
                             fontWeight: 'lighter',
-                        }}
-                        content={props.link.typeId}
-                    />
+                        }}>
+                        {props.link.typeId}
+                    </Reactodia.LinkLabel>
                 }
                 propertyLabelStartLine={2}
             />

--- a/src/templates/defaultLinkTemplate.tsx
+++ b/src/templates/defaultLinkTemplate.tsx
@@ -7,7 +7,8 @@ import { PropertyTypeIri } from '../data/model';
 import { TemplateProperties } from '../data/schema';
 
 import { LinkTemplate, LinkTemplateProps } from '../diagram/customization';
-import { LinkPath, LinkLabel, LinkLabelProps, LinkVertices } from '../diagram/linkLayer';
+import { LinkLabel, LinkLabelProps } from '../diagram/linkLayer';
+import { LinkPath, LinkVertices } from '../diagram/linkLayer';
 
 import { RelationGroup, RelationLink } from '../editor/dataElements';
 import { subscribeLinkTypes, subscribePropertyTypes } from '../editor/observedElement';
@@ -35,8 +36,7 @@ export const DefaultLinkTemplate: LinkTemplate = {
 const CLASS_NAME = 'reactodia-default-link';
 
 const PROPERTY_CLASS = `${CLASS_NAME}__property`;
-const TEXT_CLASS = `${CLASS_NAME}__label-text`;
-const BACKGROUND_CLASS = `${CLASS_NAME}__label-background`;
+const LABEL_CLASS = `${CLASS_NAME}__label`;
 
 /**
  * Props for {@link DefaultLink} component.
@@ -122,21 +122,24 @@ export function DefaultLink(props: DefaultLinkProps) {
         labelContent = <>
             <LinkLabel {...primaryLabelProps}
                 primary
-                link={link}
-                position={getPathPosition(0.5)}
                 textAnchor={route?.labelTextAnchor ?? primaryLabelProps?.textAnchor}
-                textClass={cx(TEXT_CLASS, primaryLabelProps?.textClass)}
-                rectClass={cx(BACKGROUND_CLASS, primaryLabelProps?.rectClass)}
+                className={cx(
+                    LABEL_CLASS,
+                    renamedLabel ? `${LABEL_CLASS}--renamed` : undefined,
+                    primaryLabelProps?.className
+                )}
                 title={primaryLabelProps?.title ?? t.text('default_link_template.label.title', {
                     relation: label,
                     relationIri: model.locale.formatIri(link.typeId),
                 })}
-                content={renamedLabel ? label : (
+                link={link}
+                position={getPathPosition(0.5)}>
+                {renamedLabel ? <span>{label}</span> : (
                     <WithFetchStatus type='linkType' target={link.typeId}>
-                        <tspan>{label}</tspan>
+                        <span>{label}</span>
                     </WithFetchStatus>
                 )}
-            />
+            </LinkLabel>
             {prependLabels}
             {link instanceof RelationLink ? <LinkProperties {...props} /> : null}
             {link instanceof RelationGroup ? (
@@ -144,27 +147,23 @@ export function DefaultLink(props: DefaultLinkProps) {
                     <LinkLabel className={`${CLASS_NAME}__source-count`}
                         link={link}
                         position={getPathPosition(0.1)}
-                        textClass={TEXT_CLASS}
-                        rectClass={BACKGROUND_CLASS}
                         title={t.text('default_link_template.group_source.title', {
                             value: link.itemSources.size,
-                        })}
-                        content={t.text('default_link_template.group_source.value', {
+                        })}>
+                        {t.text('default_link_template.group_source.value', {
                             value: link.itemSources.size,
                         })}
-                    />
+                    </LinkLabel>
                     <LinkLabel className={`${CLASS_NAME}__target-count`}
                         link={link}
                         position={getPathPosition(0.9)}
-                        textClass={TEXT_CLASS}
-                        rectClass={BACKGROUND_CLASS}
                         title={t.text('default_link_template.group_target.title', {
                             value: link.itemTargets.size,
-                        })}
-                        content={t.text('default_link_template.group_target.value', {
+                        })}>
+                        {t.text('default_link_template.group_target.value', {
                             value: link.itemTargets.size,
                         })}
-                    />
+                    </LinkLabel>
                 </>
             ) : null}
         </>;
@@ -177,7 +176,6 @@ export function DefaultLink(props: DefaultLinkProps) {
             className={cx(
                 CLASS_NAME,
                 link instanceof RelationGroup ? `${CLASS_NAME}--group` : undefined,
-                renamedLabel ? `${CLASS_NAME}--renamed` : undefined,
                 className
             )}>
             <LinkPath path={path}
@@ -231,19 +229,15 @@ function LinkProperties(props: DefaultLinkProps) {
                 line={propertyLabelStartLine + index}
                 textAnchor={route?.labelTextAnchor ?? propertyLabelProps?.textAnchor}
                 className={cx(PROPERTY_CLASS, propertyLabelProps?.className)}
-                textClass={cx(TEXT_CLASS, propertyLabelProps?.textClass)}
-                rectClass={cx(BACKGROUND_CLASS, propertyLabelProps?.rectClass)}
                 title={propertyLabelProps?.title ?? t.text('default_link_template.property.title', {
                     property: property.label,
                     propertyIri: model.locale.formatIri(property.iri),
-                })}
-                content={<>
-                    <WithFetchStatus type='propertyType' target={property.iri}>
-                        <tspan>{property.label}:&nbsp;</tspan>
-                    </WithFetchStatus>
-                    {property.values.map(v => v.value).join(', ')}
-                </>}
-            />
+                })}>
+                <WithFetchStatus type='propertyType' target={property.iri}>
+                    <span>{property.label}:&nbsp;</span>
+                </WithFetchStatus>
+                {property.values.map(v => v.value).join(', ')}
+            </LinkLabel>
         ))}
     </>;
 }

--- a/styles/diagram/_linkLayer.scss
+++ b/styles/diagram/_linkLayer.scss
@@ -53,3 +53,12 @@
     fill: theme.$link-stroke-color;
   }
 }
+
+.reactodia-link-label {
+  margin-top: calc(1.5em * var(--reactodia-link-label-line, 0));
+  padding: 0 2px;
+  border-radius: 2px;
+  color: theme.$font-color-base;
+  background-color: theme.$canvas-background-color;
+  white-space: nowrap;
+}

--- a/styles/templates/_defaultLink.scss
+++ b/styles/templates/_defaultLink.scss
@@ -5,44 +5,35 @@
     stroke-width: 2px;
   }
 
-  &__label-text {
-    fill: theme.$font-color-base;
-    stroke: none;
-    stroke-width: 0;
-    font-size: inherit;
+  /* Use :not([attr]) selector to avoid overriding the attribute due to SVG style priority. */
+  &__path:not([stroke]) {
+    stroke: theme.$link-stroke-color;
+  }
+
+  &__label {
     font-weight: bold;
   }
 
-  &--renamed &__label-text {
+  &__label--renamed {
     font-style: italic;
     font-weight: normal;
   }
 
-  &__property &__label-text {
+  &__property {
     font-style: normal;
     font-weight: normal;
     font-size: 90%;
+
+    max-width: 150px;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
-  &__label-background {
-    fill: theme.$canvas-background-color;
-    stroke: none;
-    stroke-width: 0;
-  }
-
-  &__source-count &__label-text,
-  &__target-count &__label-text {
-    fill: theme.$color-emphasis-600;
+  &__source-count,
+  &__target-count {
+    color: theme.$color-emphasis-600;
     font-size: 12px;
-  }
-
-  &__source-count &__label-background,
-  &__target-count &__label-background {
+    font-weight: bold;
     opacity: 80%;
-  }
-
-  /* Use :not([attr]) selector to avoid overriding the attribute due to SVG style priority. */
-  &__path:not([stroke]) {
-    stroke: theme.$link-stroke-color;
   }
 }


### PR DESCRIPTION
* **[Breaking]** `LinkLabel` content is now rendered in HTML context instead of SVG, which allows to use CSS for layout, backgrounds, etc but requires changes to the styles:
  - `textClass`, `textStyle`, `rectClass` and `rectStyle` are replaced by `className` and `style` props;
  - CSS should use HTML styling properties instead of SVG variants, e.g. `color` and `background-color` instead of `stroke` and `fill`;
  - label content should be placed directly as children to the component instead of using `content` prop.