### PR TITLE
Refactor `Paper` to have clearly defined components for HTML and SVG layers, simplify canvas export and its output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Make library compatible with [React v19](https://react.dev/blog/2024/12/05/react-19), while continuing support for v17 and v18.
 - Increase `IndexedDbCachedProvider.DB_VERSION` to 4 due to `ElementModel` changes.
 - Remove deprecated `LocaleFormatter`, `DataGraphLocaleFormatter` and `FormattedProperty` types.
+- Simplify the exported canvas SVG by using a single `<foreignObject>` to hold the whole element layer instead of a separate one for each canvas element.
 
 ## [0.29.1] - 2025-03-25
 #### 🐛 Fixed

--- a/src/diagram/elementLayer.tsx
+++ b/src/diagram/elementLayer.tsx
@@ -9,13 +9,15 @@ import { ElementTemplate, TemplateProps } from './customization';
 import { setElementExpanded } from './commands';
 import { Element, VoidElement } from './elements';
 import { DiagramModel } from './model';
+import { HtmlPaperLayer, type PaperTransform } from './paper';
 import { MutableRenderingState, RenderingLayer } from './renderingState';
 import { SharedCanvasState } from './sharedCanvasState';
 
 export interface ElementLayerProps {
+    layerRef: React.Ref<HTMLDivElement | null>;
     model: DiagramModel;
     renderingState: MutableRenderingState;
-    style: React.CSSProperties;
+    paperTransform: PaperTransform;
 }
 
 interface State {
@@ -76,7 +78,7 @@ export class ElementLayer extends React.Component<ElementLayerProps, State> {
     }
 
     render() {
-        const {style, model, renderingState} = this.props;
+        const {model, renderingState, paperTransform, layerRef} = this.props;
         const {version, elementStates} = this.state;
         const {memoizedElements} = this;
 
@@ -89,9 +91,10 @@ export class ElementLayer extends React.Component<ElementLayerProps, State> {
         }
 
         return (
-            <div key={version}
+            <HtmlPaperLayer key={version}
+                layerRef={layerRef}
                 className='reactodia-element-layer'
-                style={style}>
+                paperTransform={paperTransform}>
                 {elementsToRender.map(state => {
                     let overlaidElement = memoizedElements.get(state);
                     if (!overlaidElement) {
@@ -116,7 +119,7 @@ export class ElementLayer extends React.Component<ElementLayerProps, State> {
                     }
                     return overlaidElement;
                 })}
-            </div>
+            </HtmlPaperLayer>
         );
     }
 

--- a/src/widgets/haloLink.tsx
+++ b/src/widgets/haloLink.tsx
@@ -10,7 +10,7 @@ import {
     Rect, Spline, Vector, computePolyline, computePolylineLength, getPointAlongPolyline,
 } from '../diagram/geometry';
 import type { DiagramModel, GraphStructure } from '../diagram/model';
-import { TransformedSvgCanvas } from '../diagram/paper';
+import { SvgPaperLayer } from '../diagram/paper';
 import type { RenderingState } from '../diagram/renderingState';
 
 import {
@@ -318,11 +318,11 @@ function LinkHighlight(props: LinkHighlightProps) {
         <div className={`${CLASS_NAME}__label-highlight`}
             style={labelHighlightStyle}
         />
-        <TransformedSvgCanvas paperTransform={canvas.metrics.getTransform()}
+        <SvgPaperLayer paperTransform={canvas.metrics.getTransform()}
             style={{overflow: 'visible', pointerEvents: 'none'}}>
             <path className={`${CLASS_NAME}__path-highlight`}
                 d={spline.toPath()}
             />
-        </TransformedSvgCanvas>
+        </SvgPaperLayer>
     </>;
 }

--- a/src/widgets/visualAuthoring/authoredEntityDecorator.tsx
+++ b/src/widgets/visualAuthoring/authoredEntityDecorator.tsx
@@ -223,7 +223,8 @@ class AuthoredEntityDecoratorInner extends React.Component<AuthoredEntityDecorat
         }
         return (
             <div className={`${CLASS_NAME}__decorator`}
-                style={{position: 'absolute', transform}}>
+                style={{position: 'absolute', transform}}
+                data-reactodia-no-export='true'>
                 {outlines ? (
                     <svg className={`${CLASS_NAME}__element-outlines`}
                         width={size.width}

--- a/src/widgets/visualAuthoring/authoredRelationOverlay.tsx
+++ b/src/widgets/visualAuthoring/authoredRelationOverlay.tsx
@@ -11,7 +11,7 @@ import { CanvasApi, useCanvas } from '../../diagram/canvasApi';
 import {
     Rect, Spline, Vector, computePolyline, getPointAlongPolyline, computePolylineLength,
 } from '../../diagram/geometry';
-import { TransformedSvgCanvas } from '../../diagram/paper';
+import { SvgPaperLayer } from '../../diagram/paper';
 import { RenderingLayer } from '../../diagram/renderingState';
 import { Link } from '../../diagram/elements';
 import { HtmlSpinner } from '../../diagram/spinner';
@@ -281,10 +281,10 @@ class LinkStateWidgetInner extends React.Component<AuthoredRelationOverlayInnerP
             transform: `scale(${scale},${scale})translate(${originX}px,${originY}px)`,
         };
         return <div className={`${CLASS_NAME}`}>
-            <TransformedSvgCanvas paperTransform={transform}
+            <SvgPaperLayer paperTransform={transform}
                 style={{overflow: 'visible', pointerEvents: 'none'}}>
                 {this.renderLinkStateHighlighting()}
-            </TransformedSvgCanvas>
+            </SvgPaperLayer>
             <div className={`${CLASS_NAME}__validation-layer`} style={htmlTransformStyle}>
                 {this.renderLinkStateLabels()}
             </div>

--- a/src/widgets/visualAuthoring/dragEditLayer.tsx
+++ b/src/widgets/visualAuthoring/dragEditLayer.tsx
@@ -11,7 +11,7 @@ import { CanvasApi, useCanvas } from '../../diagram/canvasApi';
 import { Element, VoidElement } from '../../diagram/elements';
 import { SizeProvider, Vector, boundsOf, findElementAtPoint } from '../../diagram/geometry';
 import { LinkLayer, LinkMarkers } from '../../diagram/linkLayer';
-import { TransformedSvgCanvas } from '../../diagram/paper';
+import { SvgPaperLayer } from '../../diagram/paper';
 import type { MutableRenderingState } from '../../diagram/renderingState';
 import { Spinner } from '../../diagram/spinner';
 
@@ -522,7 +522,7 @@ class DragEditLayerInner extends React.Component<DragEditLayerInnerProps, State>
         const transform = canvas.metrics.getTransform();
         const renderingState = canvas.renderingState as MutableRenderingState;
         return (
-            <TransformedSvgCanvas paperTransform={transform}
+            <SvgPaperLayer paperTransform={transform}
                 className={CLASS_NAME}>
                 <LinkMarkers renderingState={renderingState} />
                 {this.renderHighlight()}
@@ -533,7 +533,7 @@ class DragEditLayerInner extends React.Component<DragEditLayerInnerProps, State>
                         links={[this.temporaryLink]}
                     />
                 )}
-            </TransformedSvgCanvas>
+            </SvgPaperLayer>
         );
     }
 

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -84,7 +84,9 @@ export {
 } from './diagram/linkLayer';
 export { type DiagramModel, DiagramModelEvents, GraphStructure } from './diagram/model';
 export {
-    PaperTransform, TransformedSvgCanvas, TransformedSvgCanvasProps, paneTopLeft, totalPaneSize,
+    type PaperTransform, paneTopLeft, totalPaneSize,
+    HtmlPaperLayer, type HtmlPaperLayerProps,
+    SvgPaperLayer, type SvgPaperLayerProps,
 } from './diagram/paper';
 export { RenderingState, RenderingStateEvents, RenderingLayer } from './diagram/renderingState';
 export {

--- a/styles/diagram/_elementLayer.scss
+++ b/styles/diagram/_elementLayer.scss
@@ -2,14 +2,11 @@
   cursor: move;
   outline: none;
 
+  // http://stackoverflow.com/questions/6664460/line-height-affects-images
+  img { vertical-align: middle; }
+
   &--blurred {
     filter: grayscale(100%);
     opacity: 0.5;
   }
-}
-
-.reactodia-overlaid-element,
-.reactodia-exported-element {
-  // http://stackoverflow.com/questions/6664460/line-height-affects-images
-  img { vertical-align: middle; }
 }

--- a/styles/diagram/_paperArea.scss
+++ b/styles/diagram/_paperArea.scss
@@ -96,3 +96,7 @@
     box-sizing: inherit;
   }
 }
+
+.reactodia-exported-layer {
+  position: absolute;
+}


### PR DESCRIPTION
* Replace `TransformedSvgCanvas` component by `SvgPaperLayer`, add similar  `HtmlPaperLayer` component for HTML-based layer transformation;
* Simplify the exported canvas SVG by using a single `<foreignObject>` to hold the whole element layer instead of a separate one for each canvas element.