### PR TITLE
Consistently export schema IRIs and RDF vocabularies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Add `ElementDecoration` component to display additional decorations over canvas elements either from the template itself or from outside the element:
   * Element decorations are not included in the computed element bounds but are exported with the canvas unless explicitly marked with `data-reactodia-no-export` attribute (as with other canvas elements);
 - Select entity label and image using `DataLocaleProvider` based on its properties:
-  * **[Breaking]** Remove `ElementModel.{label, image}` properties and instead use `DataDiagramModel.locale` methods to select them based on `ElementModel.properties` instead;
-  * Allow to override data locale provider (default is `DefaultDataLocaleProvider`) by passing `locale` option to `model.importLayout()` or `model.createNewDiagram()`.
+  * **[💥Breaking]** Remove `ElementModel.{label, image}` properties and instead use `DataDiagramModel.locale` methods to select them based on `ElementModel.properties` instead;
+  * Allow to override data locale provider (default is `DefaultDataLocaleProvider`) by passing `locale` option to `model.importLayout()` or `model.createNewDiagram()`;
 
 #### 🐛 Fixed
 - Always display validation state for an entities and relations in case when the target does not have any authoring changes.
@@ -26,11 +26,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 #### 💅 Polish
 - Export `EmptyMetadataProvider` as a stable base class to extend from when implementing custom metadata providers.
 - Re-use and un-deprecate `model.locale` formatting object with `DataLocaleProvider` interface type:
-  * **[Breaking]**: Remove `Translation.formatIri()` in favor of `locale.formatIri()`;
+  * **[💥Breaking]**: Remove `Translation.formatIri()` in favor of `locale.formatIri()`;
   * Replace other deprecated methods of `locale` with: `selectEntityLabel()`, `selectEntityImageUrl()`, `formatEntityLabel()`, `formatEntityTypeList()`;
 - Provide gradual customization options for the built-in entity and relation property editor:
   * Expose ability to customize property input in authoring forms with `inputResolver` option for `VisualAuthoring` component;
   * Export built-in inputs `FormInputList` and `FormInputText`, as well as `FormInputSingleProps` and `FormInputMultiProps` props interfaces to implement custom property inputs.
+- **[💥Breaking]** Rename the following constants for consistency in naming style:
+  * `DIAGRAM_CONTEXT_URL_V1` -> `DiagramContextV1`,
+  * `PLACEHOLDER_ELEMENT_TYPE` -> `PlaceholderEntityType`,
+  * `PLACEHOLDER_LINK_TYPE` -> `PlaceholderRelationType`;
 - Support optional dependency list in `useEventStore()` to re-subscribe to store if needed.
 
 #### 🔧 Maintenance

--- a/examples/resources/exampleMetadata.ts
+++ b/examples/resources/exampleMetadata.ts
@@ -40,7 +40,7 @@ export class ExampleMetadataProvider extends Reactodia.EmptyMetadataProvider {
             id: `${type}_${random32BitDigits}` as Reactodia.ElementIri,
             types: [type],
             properties: {
-                [Reactodia.Rdf.Vocabulary.rdfs.label]: [
+                [Reactodia.rdfs.label]: [
                     Reactodia.Rdf.DefaultDataFactory.literal(`New ${typeLabel}`)
                 ]
             },
@@ -161,10 +161,10 @@ export class ExampleMetadataProvider extends Reactodia.EmptyMetadataProvider {
             properties.set(rdfs.comment, {
                 valueShape: {termType: 'Literal'},
             });
-            properties.set(Reactodia.Rdf.Vocabulary.rdfs.label, {
+            properties.set(Reactodia.rdfs.label, {
                 valueShape: {termType: 'Literal'},
             });
-            properties.set(Reactodia.Rdf.Vocabulary.schema.thumbnailUrl, {
+            properties.set(Reactodia.schema.thumbnailUrl, {
                 valueShape: {termType: 'NamedNode'},
                 maxCount: 1,
             });

--- a/examples/stressTest.tsx
+++ b/examples/stressTest.tsx
@@ -72,8 +72,8 @@ function createLayout(
     edgesPerNode: number,
     factory: Reactodia.Rdf.DataFactory
 ): [Reactodia.Rdf.Quad[], Reactodia.ElementIri[]] {
-    const rdfType = factory.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
-    const rdfsLabel = factory.namedNode('http://www.w3.org/2000/01/rdf-schema#label');
+    const rdfType = factory.namedNode(Reactodia.rdf.type);
+    const rdfsLabel = factory.namedNode(Reactodia.rdfs.label);
     const nodeType = factory.namedNode('urn:test:Node');
     const linkType = factory.namedNode('urn:test:link');
 

--- a/src/data/rdf/rdfDataProvider.ts
+++ b/src/data/rdf/rdfDataProvider.ts
@@ -12,6 +12,7 @@ import { makeCaseInsensitiveFilter } from '../utils';
 
 import { MemoryDataset, IndexQuadBy, indexedDataset } from './memoryDataset';
 import * as Rdf from './rdfModel';
+import { rdf, rdfs, schema } from './vocabulary';
 
 /**
  * Options for {@link RdfDataProvider}.
@@ -72,10 +73,10 @@ const BLANK_PREFIX = 'urn:reactodia:blank:rdf:';
 const OWL_CLASS = 'http://www.w3.org/2002/07/owl#Class';
 const OWL_OBJECT_PROPERTY = 'http://www.w3.org/2002/07/owl#ObjectProperty';
 
-const RDF_PROPERTY = `${Rdf.Vocabulary.rdf.namespace}#Property` as const;
+const RDF_PROPERTY = `${rdf.namespace}#Property` as const;
 
-const RDFS_CLASS = `${Rdf.Vocabulary.rdfs.namespace}#Class` as const;
-const RDFS_SUB_CLASS_OF = `${Rdf.Vocabulary.rdfs.namespace}#subClassOf`;
+const RDFS_CLASS = `${rdfs.namespace}#Class` as const;
+const RDFS_SUB_CLASS_OF = `${rdfs.namespace}#subClassOf`;
 
 /**
  * Provides graph data from in-memory [RDF/JS-compatible](https://rdf.js.org/data-model-spec/)
@@ -107,11 +108,11 @@ export class RdfDataProvider implements DataProvider {
             IndexQuadBy.OP
         );
         this.acceptBlankNodes = options.acceptBlankNodes ?? true;
-        this.typePredicate = this.factory.namedNode(options.typePredicate ?? Rdf.Vocabulary.rdf.type);
+        this.typePredicate = this.factory.namedNode(options.typePredicate ?? rdf.type);
         this.labelPredicate = options.labelPredicate === null
-            ? null : this.factory.namedNode(options.labelPredicate ?? Rdf.Vocabulary.rdfs.label);
+            ? null : this.factory.namedNode(options.labelPredicate ?? rdfs.label);
         this.imagePredicate = options.imagePredicate === null
-            ? null : this.factory.namedNode(options.imagePredicate ?? Rdf.Vocabulary.schema.thumbnailUrl);
+            ? null : this.factory.namedNode(options.imagePredicate ?? schema.thumbnailUrl);
         this.elementTypeBaseTypes = (options.elementTypeBaseTypes ?? [OWL_CLASS, RDFS_CLASS])
             .map(iri => this.factory.namedNode(iri));
         this.elementSubtypePredicate = options.elementSubtypePredicate === null

--- a/src/data/rdf/rdfModel.ts
+++ b/src/data/rdf/rdfModel.ts
@@ -158,29 +158,3 @@ export function getLocalName(uri: string): string | undefined {
     }
     return uri.substring(index + 1);
 }
-
-const NAMESPACE_RDF = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
-const NAMESPACE_RDFS = 'http://www.w3.org/2000/01/rdf-schema#';
-const NAMESPACE_SCHEMA = 'http://schema.org/';
-const NAMESPACE_XSD = 'http://www.w3.org/2001/XMLSchema#';
-
-export const Vocabulary = {
-    rdf: {
-        namespace: NAMESPACE_RDF,
-        langString: `${NAMESPACE_RDF}langString`,
-        type: `${NAMESPACE_RDF}type`,
-        JSON: `${NAMESPACE_RDF}JSON`,
-    },
-    rdfs: {
-        namespace: NAMESPACE_RDFS,
-        label: `${NAMESPACE_RDFS}label`,
-    },
-    schema: {
-        namespace: NAMESPACE_SCHEMA,
-        thumbnailUrl: `${NAMESPACE_SCHEMA}thumbnailUrl`,
-    },
-    xsd: {
-        namespace: NAMESPACE_XSD,
-        string: `${NAMESPACE_XSD}string`,
-    },
-} as const;

--- a/src/data/rdf/vocabulary.ts
+++ b/src/data/rdf/vocabulary.ts
@@ -1,0 +1,45 @@
+const NAMESPACE_RDF = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
+/**
+ * Vocabulary for common terms from `rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>` namespace.
+ *
+ * @category Constants
+ */
+export const rdf = {
+    namespace: NAMESPACE_RDF,
+    langString: `${NAMESPACE_RDF}langString`,
+    type: `${NAMESPACE_RDF}type`,
+    JSON: `${NAMESPACE_RDF}JSON`,
+} as const;
+
+const NAMESPACE_RDFS = 'http://www.w3.org/2000/01/rdf-schema#';
+/**
+ * Vocabulary for common terms from `rdfs: <http://www.w3.org/2000/01/rdf-schema#>` namespace.
+ *
+ * @category Constants
+ */
+export const rdfs = {
+    namespace: NAMESPACE_RDFS,
+    label: `${NAMESPACE_RDFS}label`,
+} as const;
+
+const NAMESPACE_SCHEMA = 'http://schema.org/';
+/**
+ * Vocabulary for common terms from `schema: <http://schema.org/>` namespace.
+ *
+ * @category Constants
+ */
+export const schema = {
+    namespace: NAMESPACE_SCHEMA,
+    thumbnailUrl: `${NAMESPACE_SCHEMA}thumbnailUrl`,
+} as const;
+
+const NAMESPACE_XSD = 'http://www.w3.org/2001/XMLSchema#';
+/**
+ * Vocabulary for common terms from `xsd: <http://www.w3.org/2001/XMLSchema#>` namespace.
+ *
+ * @category Constants
+ */
+export const xsd = {
+    namespace: NAMESPACE_XSD,
+    string: `${NAMESPACE_XSD}string`,
+} as const;

--- a/src/data/schema.ts
+++ b/src/data/schema.ts
@@ -6,20 +6,19 @@ import type { ElementTypeIri, LinkTypeIri } from './model';
  *
  * @category Constants
  */
-export const DIAGRAM_CONTEXT_URL_V1 = 'https://ontodia.org/context/v1.json';
-
+export const DiagramContextV1 = 'https://ontodia.org/context/v1.json';
 /**
- * Element type for an newly created temporary entity in graph authoring mode.
+ * Type for a newly created temporary entity in graph authoring mode.
  *
  * @category Constants
  */
-export const PLACEHOLDER_ELEMENT_TYPE: ElementTypeIri = 'urn:reactodia:newElement';
+export const PlaceholderEntityType: ElementTypeIri = 'urn:reactodia:newElement';
 /**
- * Link type for an newly created temporary relation in graph authoring mode.
+ * Type for an newly created temporary relation in graph authoring mode.
  *
  * @category Constants
  */
-export const PLACEHOLDER_LINK_TYPE: LinkTypeIri = 'urn:reactodia:newLink';
+export const PlaceholderRelationType: LinkTypeIri = 'urn:reactodia:newLink';
 
 /**
  * Well-known properties for element state ({@link Element.elementState})

--- a/src/data/sparql/sparqlDataProvider.ts
+++ b/src/data/sparql/sparqlDataProvider.ts
@@ -2,6 +2,7 @@ import * as N3 from 'n3';
 
 import { multimapArrayAdd } from '../../coreUtils/collections';
 import * as Rdf from '../rdf/rdfModel';
+import { rdfs, schema } from '../rdf/vocabulary';
 import {
     ElementTypeModel, ElementTypeGraph, LinkTypeModel, ElementModel, LinkModel, PropertyTypeModel,
     ElementIri, ElementTypeIri, LinkTypeIri, PropertyTypeIri,
@@ -251,8 +252,8 @@ export class SparqlDataProvider implements DataProvider {
         this.openWorldProperties = settings.propertyConfigurations.length === 0 ||
             Boolean(settings.openWorldProperties);
 
-        this.labelPredicate = prepareLabelPredicate ?? Rdf.Vocabulary.rdfs.label;
-        this.imagePredicate = prepareImagePredicate ?? Rdf.Vocabulary.schema.thumbnailUrl;
+        this.labelPredicate = prepareLabelPredicate ?? rdfs.label;
+        this.imagePredicate = prepareImagePredicate ?? schema.thumbnailUrl;
     }
 
     private async queryChunked<T extends string>(

--- a/src/editor/dataLocaleProvider.ts
+++ b/src/editor/dataLocaleProvider.ts
@@ -2,6 +2,7 @@ import type { Translation } from '../coreUtils/i18n';
 
 import { ElementModel, PropertyTypeIri, isEncodedBlank } from '../data/model';
 import * as Rdf from '../data/rdf/rdfModel';
+import { rdfs, schema } from '../data/rdf/vocabulary';
 
 import type { DataDiagramModel } from './dataDiagramModel';
 
@@ -52,23 +53,34 @@ export interface DefaultDataLocaleProviderOptions {
      */
     readonly translation: Translation;
     /**
-     * Property IRI to select labels from for an entity.
+     * Property IRIs to select labels from for an entity.
+     *
+     * The values of a first property in the sequence with a non-empty value set are selected.
+     *
+     * @default ["http://www.w3.org/2000/01/rdf-schema#label"]
      */
-    readonly labelProperty?: PropertyTypeIri | undefined;
+    readonly labelProperties?: readonly PropertyTypeIri[];
     /**
-     * Property IRI to select image URL from for an entity.
+     * Property IRIs to select image URL from for an entity.
+     *
+     * The first found value of a property in the sequence is selected as an entity image.
+     *
+     * @default ["http://schema.org/thumbnailUrl"]
      */
-    readonly imageProperty?: PropertyTypeIri | undefined;
+    readonly imageProperties?: readonly PropertyTypeIri[];
 }
 
 /**
- * Provides a default graph data formatter implementation.
+ * Provides a default graph data locale provider implementation.
+ *
+ * The default provider uses {@link rdfs.label} and {@link schema.thumbnailUrl}
+ * properties to get labels and image URLs unless overridden with options.
  */
 export class DefaultDataLocaleProvider implements DataLocaleProvider {
     protected readonly model: DataDiagramModel;
     protected readonly translation: Translation;
-    private readonly labelProperty: PropertyTypeIri | undefined;
-    private readonly imageProperty: PropertyTypeIri | undefined;
+    private readonly labelProperties: readonly PropertyTypeIri[];
+    private readonly imageProperties: readonly PropertyTypeIri[];
 
     private readonly EMPTY_LABELS: readonly Rdf.Literal[] = [];
 
@@ -76,29 +88,32 @@ export class DefaultDataLocaleProvider implements DataLocaleProvider {
         const {
             model,
             translation,
-            labelProperty = Rdf.Vocabulary.rdfs.label,
-            imageProperty = Rdf.Vocabulary.schema.thumbnailUrl,
+            labelProperties = [rdfs.label],
+            imageProperties = [schema.thumbnailUrl],
         } = options;
         this.model = model;
         this.translation = translation;
-        this.labelProperty = labelProperty;
-        this.imageProperty = imageProperty;
+        this.labelProperties = labelProperties;
+        this.imageProperties = imageProperties;
     }
 
     selectEntityLabel(entity: ElementModel): readonly Rdf.Literal[] {
-        if (this.labelProperty !== undefined) {
-            if (Object.prototype.hasOwnProperty.call(entity.properties, this.labelProperty)) {
-                const values = entity.properties[this.labelProperty];
-                return values ? filterInLiterals(values) : this.EMPTY_LABELS;
+        for (const property of this.labelProperties) {
+            if (Object.prototype.hasOwnProperty.call(entity.properties, property)) {
+                const values = entity.properties[property];
+                const literals = values ? filterInLiterals(values) : this.EMPTY_LABELS;
+                if (literals.length > 0) {
+                    return literals;
+                }
             }
         }
         return this.EMPTY_LABELS;
     }
 
     selectEntityImageUrl(entity: ElementModel): string | undefined {
-        if (this.imageProperty !== undefined) {
-            if (Object.prototype.hasOwnProperty.call(entity.properties, this.imageProperty)) {
-                const values = entity.properties[this.imageProperty];
+        for (const property of this.imageProperties) {
+            if (Object.prototype.hasOwnProperty.call(entity.properties, property)) {
+                const values = entity.properties[property];
                 if (values && values.length > 0) {
                     return values[0].value;
                 }

--- a/src/editor/serializedDiagram.ts
+++ b/src/editor/serializedDiagram.ts
@@ -1,5 +1,5 @@
 import { ElementIri, ElementModel, LinkTypeIri } from '../data/model';
-import { TemplateProperties, DIAGRAM_CONTEXT_URL_V1, PLACEHOLDER_LINK_TYPE } from '../data/schema';
+import { DiagramContextV1, PlaceholderRelationType, TemplateProperties } from '../data/schema';
 
 import { Element, ElementTemplateState, Link, LinkTemplateState, LinkTypeVisibility } from '../diagram/elements';
 import { Vector } from '../diagram/geometry';
@@ -116,7 +116,7 @@ export interface SerializedLayoutLinkItem {
  */
 export function emptyDiagram(): SerializedDiagram {
     return {
-        '@context': DIAGRAM_CONTEXT_URL_V1,
+        '@context': DiagramContextV1,
         '@type': 'Diagram',
         layoutData: {
             '@type': 'Layout',
@@ -150,7 +150,7 @@ export function serializeDiagram(diagram: DeserializedDiagram): SerializedDiagra
         linkTypeOptions = [];
         for (const [linkTypeIri, visibility] of linkTypeVisibility) {
             // Do not serialize default link type options
-            if  (visibility !== 'visible' && linkTypeIri !== PLACEHOLDER_LINK_TYPE) {
+            if  (visibility !== 'visible' && linkTypeIri !== PlaceholderRelationType) {
                 linkTypeOptions.push({
                     '@type': 'LinkTypeOptions',
                     property: linkTypeIri,

--- a/src/forms/elementTypeSelector.tsx
+++ b/src/forms/elementTypeSelector.tsx
@@ -5,7 +5,7 @@ import { mapAbortedToNull } from '../coreUtils/async';
 import { EventObserver } from '../coreUtils/events';
 import { Translation } from '../coreUtils/i18n';
 
-import { PLACEHOLDER_ELEMENT_TYPE } from '../data/schema';
+import { PlaceholderEntityType } from '../data/schema';
 import { ElementModel, ElementTypeIri } from '../data/model';
 import { DataProviderLookupItem } from '../data/dataProvider';
 
@@ -245,7 +245,7 @@ export class ElementTypeSelectorInner extends React.Component<ElementTypeSelecto
                             name='reactodia-element-type-selector-select'
                             value={value}
                             onChange={this.onElementTypeChange}>
-                            <option value={PLACEHOLDER_ELEMENT_TYPE} disabled={true}>
+                            <option value={PlaceholderEntityType} disabled={true}>
                                 {t.text('visual_authoring.select_entity.type.placeholder')}
                             </option>
                             {
@@ -358,7 +358,7 @@ export function validateElementType(
     workspace: WorkspaceContext
 ): Promise<Pick<ElementValue, 'error' | 'allowChange'>> {
     const {translation: t} = workspace;
-    const isElementTypeSelected = element.types.indexOf(PLACEHOLDER_ELEMENT_TYPE) < 0;
+    const isElementTypeSelected = element.types.indexOf(PlaceholderEntityType) < 0;
     const error = isElementTypeSelected
         ? undefined
         : t.text('visual_authoring.select_entity.validation.error_required');

--- a/src/forms/input/formInputText.tsx
+++ b/src/forms/input/formInputText.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { useTranslation } from '../../coreUtils/i18n';
 
 import * as Rdf from '../../data/rdf/rdfModel';
+import { rdf, xsd } from '../../data/rdf/vocabulary';
 
 import { type FormInputSingleProps } from './inputCommon';
 
@@ -49,8 +50,8 @@ export function FormInputText(props: FormInputTextProps) {
     const Component = multiline ? 'textarea' : 'input';
     const hasLanguageSelector = valueShape.termType === 'Literal' && (
         !valueShape.datatype ||
-        valueShape.datatype.value === Rdf.Vocabulary.rdf.langString ||
-        valueShape.datatype.value === Rdf.Vocabulary.xsd.string
+        valueShape.datatype.value === rdf.langString ||
+        valueShape.datatype.value === xsd.string
     );
 
     return (

--- a/src/forms/linkTypeSelector.tsx
+++ b/src/forms/linkTypeSelector.tsx
@@ -5,7 +5,7 @@ import { EventObserver } from '../coreUtils/events';
 import { Translation } from '../coreUtils/i18n';
 
 import { ElementModel, LinkModel, LinkDirection, LinkTypeIri, equalLinks, LinkKey } from '../data/model';
-import { PLACEHOLDER_LINK_TYPE } from '../data/schema';
+import { PlaceholderRelationType } from '../data/schema';
 
 import { HtmlSpinner } from '../diagram/spinner';
 
@@ -258,7 +258,7 @@ export async function validateLinkType(
     signal: AbortSignal | undefined
 ): Promise<Pick<ValidatedLink, 'error' | 'allowChange'>> {
     const {model, editor, translation: t} = workspace;
-    if (currentLink.linkTypeId === PLACEHOLDER_LINK_TYPE) {
+    if (currentLink.linkTypeId === PlaceholderRelationType) {
         return {
             error: t.text('visual_authoring.select_relation.validation.error_required'),
             allowChange: true,

--- a/src/legacy-styles.tsx
+++ b/src/legacy-styles.tsx
@@ -167,7 +167,7 @@ export function makeOntologyLinkTemplates(Reactodia: typeof import('./workspace'
             return LINK_RANGE;
         } else if (type === 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type') {
             return LINK_TYPE_OF;
-        } else if (type === Reactodia.PLACEHOLDER_LINK_TYPE) {
+        } else if (type === Reactodia.PlaceholderRelationType) {
             return {...Reactodia.DefaultLinkTemplate, markerTarget: {fill: 'none'}};
         } else {
             return undefined;

--- a/src/widgets/visualAuthoring/dragEditLayer.tsx
+++ b/src/widgets/visualAuthoring/dragEditLayer.tsx
@@ -5,7 +5,7 @@ import { EventObserver } from '../../coreUtils/events';
 
 import { MetadataCanConnect } from '../../data/metadataProvider';
 import { ElementModel, ElementTypeIri, LinkTypeIri } from '../../data/model';
-import { PLACEHOLDER_ELEMENT_TYPE, PLACEHOLDER_LINK_TYPE } from '../../data/schema';
+import { PlaceholderEntityType, PlaceholderRelationType } from '../../data/schema';
 
 import { CanvasApi, useCanvas } from '../../diagram/canvasApi';
 import { Element, VoidElement } from '../../diagram/elements';
@@ -157,14 +157,14 @@ class DragEditLayerInner extends React.Component<DragEditLayerInnerProps, State>
             sourceId: source.id,
             targetId: temporaryElement.id,
             data: {
-                linkTypeId: linkType ?? PLACEHOLDER_LINK_TYPE,
+                linkTypeId: linkType ?? PlaceholderRelationType,
                 sourceId: source.iri,
                 targetId: '',
                 properties: {},
             },
         });
         const temporaryLink = editor.createRelation(linkTemplate, {temporary: true});
-        model.setLinkVisibility(PLACEHOLDER_LINK_TYPE, 'withoutLabel');
+        model.setLinkVisibility(PlaceholderRelationType, 'withoutLabel');
 
         batch.discard();
 
@@ -246,7 +246,7 @@ class DragEditLayerInner extends React.Component<DragEditLayerInnerProps, State>
             editor.metadataProvider.canConnect(
                 source.data,
                 undefined,
-                link.data.linkTypeId === PLACEHOLDER_LINK_TYPE
+                link.data.linkTypeId === PlaceholderRelationType
                     ? undefined : link.data.linkTypeId,
                 {signal: this.cancellation.signal}
             ),
@@ -304,7 +304,7 @@ class DragEditLayerInner extends React.Component<DragEditLayerInnerProps, State>
             editor.metadataProvider.canConnect(
                 source,
                 target,
-                link.data.linkTypeId === PLACEHOLDER_LINK_TYPE
+                link.data.linkTypeId === PlaceholderRelationType
                     ? undefined : link.data.linkTypeId,
                 {signal}
             ),
@@ -411,7 +411,7 @@ class DragEditLayerInner extends React.Component<DragEditLayerInnerProps, State>
                 elementTypes.add(typeIri);
             }
         }
-        const selectedType = elementTypes.size === 1 ? Array.from(elementTypes)[0] : PLACEHOLDER_ELEMENT_TYPE;
+        const selectedType = elementTypes.size === 1 ? Array.from(elementTypes)[0] : PlaceholderEntityType;
         const elementModel = await editor.metadataProvider.createEntity(
             selectedType,
             {signal: this.cancellation.signal}
@@ -457,7 +457,7 @@ class DragEditLayerInner extends React.Component<DragEditLayerInnerProps, State>
             linkTypeIri = singleOutLink;
             direction = model.findLink(linkTypeIri, source.id, target.id) ? 'in' : 'out';
         } else {
-            linkTypeIri = PLACEHOLDER_LINK_TYPE;
+            linkTypeIri = PlaceholderRelationType;
             direction = 'out';
         }
 

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -29,8 +29,8 @@ export {
     ValidationSeverity,
 } from './data/validationProvider';
 export {
+    DiagramContextV1, PlaceholderEntityType, PlaceholderRelationType,
     TemplateProperties, PinnedProperties,
-    DIAGRAM_CONTEXT_URL_V1, PLACEHOLDER_ELEMENT_TYPE, PLACEHOLDER_LINK_TYPE,
 } from './data/schema';
 export * from './data/composite/composite';
 export {
@@ -48,6 +48,7 @@ export * from './data/rdf/rdfDataProvider';
  * @category Core
  */
 export * as Rdf from './data/rdf/rdfModel';
+export * from './data/rdf/vocabulary';
 export * from './data/sparql/sparqlDataProvider';
 export * from './data/sparql/sparqlDataProviderSettings';
 


### PR DESCRIPTION
* **[Breaking]** Rename constants:
  - `DIAGRAM_CONTEXT_URL_V1` -> `DiagramContextV1`,
  - `PLACEHOLDER_ELEMENT_TYPE` -> `PlaceholderEntityType`,
  - `PLACEHOLDER_LINK_TYPE` -> `PlaceholderRelationType`;
* Export RDF vocabularies directly from main entry point, e.g. `Reactodia.rdfs.label`, etc.