### PR TITLE
Support bottom-docked dropdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   * `DIAGRAM_CONTEXT_URL_V1` -> `DiagramContextV1`,
   * `PLACEHOLDER_ELEMENT_TYPE` -> `PlaceholderEntityType`,
   * `PLACEHOLDER_LINK_TYPE` -> `PlaceholderRelationType`;
+- Support the ability to expand up the `Dropdown`, `DropdownMenu` and `Toolbar` by setting `direction` to `"up"` e.g. for docking the toolbar to the bottom of the viewport.
 - Support optional dependency list in `useEventStore()` to re-subscribe to store if needed.
 
 #### 🔧 Maintenance

--- a/src/widgets/toolbar.tsx
+++ b/src/widgets/toolbar.tsx
@@ -52,13 +52,15 @@ const CLASS_NAME = 'reactodia-toolbar';
 export function Toolbar(props: ToolbarProps) {
     const {dock, dockOffsetX, dockOffsetY, menu, children} = props;
     const t = useTranslation();
+    const dropUp = dock === 's' || dock === 'sw' || dock === 'se';
     return (
         <ViewportDock dock={dock}
             dockOffsetX={dockOffsetX}
             dockOffsetY={dockOffsetY}>
-            <div className={CLASS_NAME}>
+            <div className={cx(CLASS_NAME, dropUp ? `${CLASS_NAME}--drop-up` : undefined)}>
                 {menu ? (
                     <DropdownMenu className={`${CLASS_NAME}__menu`}
+                        direction={dropUp ? 'up' : 'down'}
                         title={t.text('toolbar.menu_toggle.title')}>
                         {menu}
                     </DropdownMenu>

--- a/src/widgets/utility/dropdown.tsx
+++ b/src/widgets/utility/dropdown.tsx
@@ -12,6 +12,12 @@ export interface DropdownProps {
      */
     className?: string;
     /**
+     * Dropdown expand direction.
+     *
+     * @default "down"
+     */
+    direction?: 'down' | 'up';
+    /**
      * Whether the dropdown should be rendering in the expanded state.
      */
     expanded: boolean;
@@ -39,7 +45,7 @@ const CLASS_NAME = 'reactodia-dropdown';
  * @category Components
  */
 export function Dropdown(props: DropdownProps) {
-    const {className, expanded, toggle, onClickOutside, children} = props;
+    const {className, direction = 'down', expanded, toggle, onClickOutside, children} = props;
     const menuRef = React.useRef<HTMLElement | null>(null);
 
     React.useLayoutEffect(() => {
@@ -60,12 +66,14 @@ export function Dropdown(props: DropdownProps) {
             className={cx(
                 className,
                 CLASS_NAME,
+                direction === 'down' ? `${CLASS_NAME}--down` : `${CLASS_NAME}--up`,
                 expanded ? `${CLASS_NAME}--expanded` : `${CLASS_NAME}--collapsed`
             )}>
-            {toggle}
+            {direction === 'down' ? toggle : null}
             <div className={`${CLASS_NAME}__content`}>
                 {children}
             </div>
+            {direction === 'up' ? toggle : null}
         </nav>
     );
 }
@@ -80,6 +88,12 @@ export interface DropdownMenuProps {
      * Additional CSS class for the component.
      */
     className?: string;
+    /**
+     * Dropdown menu expand direction.
+     *
+     * @default "down"
+     */
+    direction?: 'down' | 'up';
     /**
      * Title for the toggle menu button.
      */
@@ -98,7 +112,7 @@ const MENU_CLASS_NAME = 'reactodia-dropdown-menu';
  * @category Components
  */
 export function DropdownMenu(props: DropdownMenuProps) {
-    const {className, title, children} = props;
+    const {className, direction, title, children} = props;
     const [expanded, setExpanded] = React.useState(false);
     const providedContext = React.useMemo(
         (): DropdownMenuContext => ({expanded, setExpanded}),
@@ -108,6 +122,7 @@ export function DropdownMenu(props: DropdownMenuProps) {
     return (
         <DropdownMenuContext.Provider value={providedContext}>
             <Dropdown className={cx(className, MENU_CLASS_NAME)}
+                direction={direction}
                 expanded={expanded}
                 toggle={
                     <DropdownMenuToggleButton title={title} />

--- a/src/workspace/defaultWorkspace.tsx
+++ b/src/workspace/defaultWorkspace.tsx
@@ -211,6 +211,9 @@ export function DefaultWorkspace(props: DefaultWorkspaceProps) {
         }
     ], []);
 
+    const menuDock = mainToolbar?.dock ?? 'nw';
+    const menuDropUp = menuDock === 's' || menuDock === 'sw' || menuDock === 'se';
+
     return (
         <WorkspaceRoot colorScheme={colorScheme}>
             <Canvas {...canvas}>
@@ -231,10 +234,11 @@ export function DefaultWorkspace(props: DefaultWorkspaceProps) {
                     />
                 )}
                 <Toolbar {...mainToolbar}
-                    dock={mainToolbar?.dock ?? 'nw'}
+                    dock={menuDock}
                     menu={menuContent}>
                     {search === null ? null : (
                         <UnifiedSearch {...search}
+                            direction={search?.direction ?? (menuDropUp ? 'up' : 'down')}
                             sections={search?.sections ?? defaultSections}
                         />
                     )}

--- a/styles/utility/_dropdown.scss
+++ b/styles/utility/_dropdown.scss
@@ -16,6 +16,10 @@
     transition: opacity 0.1s ease-in-out;
   }
 
+  &--up &__content {
+    bottom: 100%;
+  }
+
   &--expanded &__content {
     box-shadow: theme.$canvas-box-shadow;
   }
@@ -29,10 +33,16 @@
 }
 
 .reactodia-dropdown-menu {
-  .reactodia-dropdown--expanded &__toggle {
+  .reactodia-dropdown--down.reactodia-dropdown--expanded &__toggle {
     border-bottom: none;
     border-bottom-left-radius: unset;
     border-bottom-right-radius: unset;
+  }
+
+  .reactodia-dropdown--up.reactodia-dropdown--expanded &__toggle {
+    border-top: none;
+    border-top-left-radius: unset;
+    border-top-right-radius: unset;
   }
 
   &__toggle {
@@ -46,25 +56,39 @@
     padding: 0;
     list-style: none;
     display: flex;
-    flex-direction: column;
     background-color: theme.$background-color-surface;
   }
 
-  .reactodia-dropdown-menu-item {
-    border-radius: unset;
+  .reactodia-dropdown--down &__items {
+    flex-direction: column;
   }
 
-  .reactodia-dropdown-menu-item:first-child {
-    border-top-right-radius: theme.$button-border-radius;
-  }
-
-  .reactodia-dropdown-menu-item:last-child {
-    border-bottom-left-radius: theme.$button-border-radius;
-    border-bottom-right-radius: theme.$button-border-radius;
+  .reactodia-dropdown--up &__items {
+    flex-direction: column-reverse;
   }
 }
 
 .reactodia-dropdown-menu-item {
+  border-radius: unset;
+
+  .reactodia-dropdown--down &:first-child {
+    border-top-right-radius: theme.$button-border-radius;
+  }
+
+  .reactodia-dropdown--down &:last-child {
+    border-bottom-left-radius: theme.$button-border-radius;
+    border-bottom-right-radius: theme.$button-border-radius;
+  }
+
+  .reactodia-dropdown--up &:first-child {
+    border-bottom-right-radius: theme.$button-border-radius;
+  }
+
+  .reactodia-dropdown--up &:last-child {
+    border-top-left-radius: theme.$button-border-radius;
+    border-top-right-radius: theme.$button-border-radius;
+  }
+
   & ~ & {
     margin-top: calc(-1 * theme.$button-border-width);
     border-top-color: theme.$button-default-border-color;

--- a/styles/widgets/_toolbar.scss
+++ b/styles/widgets/_toolbar.scss
@@ -2,6 +2,7 @@
 @use "../mixin/zIndex";
 
 .reactodia-toolbar {
+  display: flex;
   /* Prevent buttons to wrap after menu button if width is too small */
   white-space: nowrap;
 
@@ -10,6 +11,10 @@
   > * {
     pointer-events: auto;
     white-space: normal;
+  }
+
+  &--drop-up {
+    align-items: flex-end;
   }
 
   &__menu {

--- a/styles/widgets/_unifiedSearch.scss
+++ b/styles/widgets/_unifiedSearch.scss
@@ -79,7 +79,6 @@ $searchButtonTotal: $searchButtonWidth + $searchButtonPadding * 2;
     background: 0 0;
     border: 0;
     border-radius: theme.$input-border-radius;
-    border-top-left-radius: unset;
     transition: background-color theme.$transition-duration;
 
     &:hover {
@@ -88,13 +87,32 @@ $searchButtonTotal: $searchButtonWidth + $searchButtonPadding * 2;
     }
   }
 
-  .reactodia-dropdown--expanded &__collapse-button,
-  .reactodia-dropdown--expanded &__clear-button {
+  .reactodia-dropdown--down &__collapse-button,
+  .reactodia-dropdown--down &__clear-button {
+    border-top-left-radius: unset;
+  }
+
+  .reactodia-dropdown--down.reactodia-dropdown--expanded &__collapse-button,
+  .reactodia-dropdown--down.reactodia-dropdown--expanded &__clear-button {
     border-bottom-right-radius: unset;
   }
 
-  &__collapse-button::after {
+  .reactodia-dropdown--up &__collapse-button,
+  .reactodia-dropdown--up &__clear-button {
+    border-bottom-left-radius: unset;
+  }
+
+  .reactodia-dropdown--up.reactodia-dropdown--expanded &__collapse-button,
+  .reactodia-dropdown--up.reactodia-dropdown--expanded &__clear-button {
+    border-top-right-radius: unset;
+  }
+
+  .reactodia-dropdown--down &__collapse-button::after {
     @include codicon("chevron-up");
+  }
+
+  .reactodia-dropdown--up &__collapse-button::after {
+    @include codicon("chevron-down");
   }
 
   &__clear-button::after {


### PR DESCRIPTION
* Support the ability to expand up the `Dropdown`, `DropdownMenu` and `Toolbar` by setting `direction` to `"up"` e.g. for docking the toolbar to the bottom of the viewport;