### PR TITLE
Finalize library before v0.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 #### 💅 Polish
 - Export `BaseMetadataProvider` as a stable base to instantiate or extend when implementing custom metadata providers.
 - Re-use and un-deprecate `model.locale` formatting object with `DataLocaleProvider` interface type:
-  * **[💥Breaking]**: Remove `Translation.formatIri()` in favor of `locale.formatIri()`;
+  * Deprecate `Translation.formatIri()` in favor of `locale.formatIri()`;
   * Replace other deprecated methods of `locale` with: `selectEntityLabel()`, `selectEntityImageUrl()`, `formatEntityLabel()`, `formatEntityTypeList()`;
 - Provide gradual customization options for the built-in entity and relation property editor:
   * Expose ability to customize property input in authoring forms with `inputResolver` option for `VisualAuthoring` component;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Optimize diagram loading time by avoiding unnecessary updates and separating a measuring element sizes step from applying the sizes to the rendering state.
 
 #### 💅 Polish
-- Export `EmptyMetadataProvider` as a stable base class to extend from when implementing custom metadata providers.
+- Export `BaseMetadataProvider` as a stable base to instantiate or extend when implementing custom metadata providers.
 - Re-use and un-deprecate `model.locale` formatting object with `DataLocaleProvider` interface type:
   * **[💥Breaking]**: Remove `Translation.formatIri()` in favor of `locale.formatIri()`;
   * Replace other deprecated methods of `locale` with: `selectEntityLabel()`, `selectEntityImageUrl()`, `formatEntityLabel()`, `formatEntityTypeList()`;

--- a/examples/graphAuthoring.tsx
+++ b/examples/graphAuthoring.tsx
@@ -41,7 +41,6 @@ function GraphAuthoringExample() {
                 model.createElement('http://www.w3.org/ns/org#subOrganizationOf'),
                 model.createElement('http://www.w3.org/ns/org#unitOf'),
             ];
-            model.history.execute(Reactodia.setElementExpanded(elements[0], true));
             await Promise.all([
                 model.requestElementData(elements.map(el => el.iri)),
                 model.requestLinks(),

--- a/examples/rdfExplorer.tsx
+++ b/examples/rdfExplorer.tsx
@@ -49,9 +49,14 @@ function RdfExample() {
                 }
                 languages={[
                     {code: 'de', label: 'Deutsch'},
-                    {code: 'en', label: 'english'},
-                    {code: 'es', label: 'español'},
-                    {code: 'ru', label: 'русский'},
+                    {code: 'en', label: 'English'},
+                    {code: 'es', label: 'Español'},
+                    {code: 'fr', label: 'Français'},
+                    {code: 'hi', label: 'हिन्दी'},
+                    {code: 'it', label: 'Italiano'},
+                    {code: 'ja', label: '日本語'},
+                    {code: 'pt', label: 'português'},
+                    {code: 'ru', label: 'Русский'},
                     {code: 'zh', label: '汉语'},
                 ]}
             />

--- a/examples/resources/exampleMetadata.ts
+++ b/examples/resources/exampleMetadata.ts
@@ -18,189 +18,153 @@ const rdfs = vocabulary('http://www.w3.org/2000/01/rdf-schema#', [
 
 const SIMULATED_DELAY: number = 200; /* ms */
 
-export class ExampleMetadataProvider extends Reactodia.EmptyMetadataProvider {
+export class ExampleMetadataProvider extends Reactodia.BaseMetadataProvider {
     private readonly propertyTypes = [owl.AnnotationProperty, owl.DatatypeProperty, owl.ObjectProperty];
     private readonly editableTypes = new Set([owl.Class, ...this.propertyTypes]);
     private readonly editableRelations = new Set<Reactodia.LinkTypeIri>([rdfs.domain, rdfs.range]);
     private readonly literalLanguages: ReadonlyArray<string> = ['de', 'en', 'es', 'ru', 'zh'];
 
-    getLiteralLanguages(): ReadonlyArray<string> {
-        return this.literalLanguages;
-    }
-
-    async createEntity(
-        type: Reactodia.ElementTypeIri,
-        options: { readonly signal?: AbortSignal }
-    ): Promise<Reactodia.ElementModel> {
-        await Reactodia.delay(SIMULATED_DELAY, {signal: options.signal});
-        const random32BitDigits = Math.floor((1 + Math.random()) * 0x100000000)
-            .toString(16).substring(1);
-        const typeLabel = Reactodia.Rdf.getLocalName(type) ?? 'Entity';
-        return {
-            id: `${type}_${random32BitDigits}` as Reactodia.ElementIri,
-            types: [type],
-            properties: {
-                [Reactodia.rdfs.label]: [
-                    Reactodia.Rdf.DefaultDataFactory.literal(`New ${typeLabel}`)
-                ]
-            },
-        };
-    }
-
-    async createRelation(
-        source: Reactodia.ElementModel,
-        target: Reactodia.ElementModel,
-        linkType: Reactodia.LinkTypeIri,
-        options: { readonly signal?: AbortSignal }
-    ): Promise<Reactodia.LinkModel> {
-        await Reactodia.delay(SIMULATED_DELAY, {signal: options.signal});
-        return {
-            sourceId: source.id,
-            targetId: target.id,
-            linkTypeId: linkType,
-            properties: {},
-        };
-    }
-
-    async canConnect(
-        source: Reactodia.ElementModel,
-        target: Reactodia.ElementModel | undefined,
-        linkType: Reactodia.LinkTypeIri | undefined,
-        options: { readonly signal?: AbortSignal }
-    ): Promise<Reactodia.MetadataCanConnect[]> {
-        await Reactodia.delay(SIMULATED_DELAY, {signal: options.signal});
-
-        const connections: Reactodia.MetadataCanConnect[] = [];
-        const addConnections = (
-            types: readonly Reactodia.ElementTypeIri[],
-            allOutLinks: readonly Reactodia.LinkTypeIri[],
-            allInLinks: readonly Reactodia.LinkTypeIri[]
-        ) => {
-            const outLinks = linkType
-                ? allOutLinks.filter(type => type === linkType)
-                : allOutLinks;
-            const inLinks = linkType
-                ? allInLinks.filter(type => type === linkType)
-                : allInLinks;
-            if (types.length > 0 && (outLinks.length > 0 || inLinks.length > 0)) {
-                connections.push({targetTypes: new Set(types), outLinks, inLinks});
-            }
-        };
-
-        if (hasType(source, owl.Class)) {
-            if (hasType(target, owl.Class)) {
-                addConnections([owl.Class], [rdfs.subClassOf], [rdfs.subClassOf]);
-            }
-
-            const targetPropertyTypes = this.propertyTypes.filter(type => hasType(target, type));
-            if (targetPropertyTypes.length > 0) {
-                addConnections(targetPropertyTypes, [], [rdfs.domain, rdfs.range]);
-            }
-        }
-
-        const sourcePropertyTypes = this.propertyTypes.filter(type => hasType(source, type));
-        if (sourcePropertyTypes.length > 0) {
-            for (const type of sourcePropertyTypes) {
-                if (hasType(target, type)) {
-                    addConnections([type], [rdfs.subPropertyOf], [rdfs.subPropertyOf]);
-                }
-            }
-
-            if (hasType(target, owl.Class)) {
-                addConnections([owl.Class], [rdfs.domain, rdfs.range], []);
-            }
-        }
-
-        return connections;
-    }
-
-    async canModifyEntity(
-        entity: Reactodia.ElementModel,
-        options: { readonly signal?: AbortSignal; }
-    ): Promise<Reactodia.MetadataCanModifyEntity> {
-        await Reactodia.delay(SIMULATED_DELAY, {signal: options.signal});
-        const editable = entity.types.some(type => this.editableTypes.has(type));
-        return {
-            canChangeIri: entity.types.includes(owl.Class),
-            canEdit: editable,
-            canDelete: editable,
-        };
-    }
-
-    async canModifyRelation(
-        link: Reactodia.LinkModel,
-        source: Reactodia.ElementModel,
-        target: Reactodia.ElementModel,
-        options: { readonly signal?: AbortSignal; }
-    ): Promise<Reactodia.MetadataCanModifyRelation> {
-        await Reactodia.delay(SIMULATED_DELAY, {signal: options.signal});
-        switch (link.linkTypeId) {
-            case rdfs.domain:
-            case rdfs.range:
-            case rdfs.subClassOf:
-            case rdfs.subPropertyOf: {
+    constructor() {
+        super({
+            getLiteralLanguages: () => this.literalLanguages,
+            createEntity: async (type, {signal}) => {
+                await Reactodia.delay(SIMULATED_DELAY, {signal});
+                const random32BitDigits = Math.floor((1 + Math.random()) * 0x100000000)
+                    .toString(16).substring(1);
+                const typeLabel = Reactodia.Rdf.getLocalName(type) ?? 'Entity';
                 return {
-                    canChangeType: true,
-                    canEdit: this.editableRelations.has(link.linkTypeId),
-                    canDelete: true,
+                    id: `${type}_${random32BitDigits}`,
+                    types: [type],
+                    properties: {
+                        [Reactodia.rdfs.label]: [
+                            Reactodia.Rdf.DefaultDataFactory.literal(`New ${typeLabel}`)
+                        ]
+                    },
                 };
-            }
-            default: {
-                return {};
-            }
-        }
-    }
-
-    async getEntityShape(
-        types: ReadonlyArray<Reactodia.ElementTypeIri>,
-        options: { readonly signal?: AbortSignal; }
-    ): Promise<Reactodia.MetadataEntityShape> {
-        await Reactodia.delay(SIMULATED_DELAY, {signal: options.signal});
-        const properties = new Map<Reactodia.PropertyTypeIri, Reactodia.MetadataPropertyShape>();
-        if (types.some(type => this.editableTypes.has(type))) {
-            properties.set(rdfs.comment, {
-                valueShape: {termType: 'Literal'},
-            });
-            properties.set(Reactodia.rdfs.label, {
-                valueShape: {termType: 'Literal'},
-            });
-            properties.set(Reactodia.schema.thumbnailUrl, {
-                valueShape: {termType: 'NamedNode'},
-                maxCount: 1,
-            });
-            properties.set(rdfs.seeAlso, {
-                valueShape: {termType: 'NamedNode'},
-                maxCount: 1,
-            });
-        }
-        return {
-            extraProperty: {
-                valueShape: {termType: 'Literal'},
             },
-            properties,
-        };
-    }
+            createRelation: async (source, target, linkType, {signal}) => {
+                await Reactodia.delay(SIMULATED_DELAY, {signal: signal});
+                return {
+                    sourceId: source.id,
+                    targetId: target.id,
+                    linkTypeId: linkType,
+                    properties: {},
+                };
+            },
+            canConnect: async (source, target, linkType, {signal}) => {
+                await Reactodia.delay(SIMULATED_DELAY, {signal});
 
-    async getRelationShape(
-        linkType: Reactodia.LinkTypeIri,
-        options: { readonly signal?: AbortSignal; }
-    ): Promise<Reactodia.MetadataRelationShape> {
-        await Reactodia.delay(SIMULATED_DELAY, {signal: options.signal});
-        const properties = new Map<Reactodia.PropertyTypeIri, Reactodia.MetadataPropertyShape>();
-        if (this.editableRelations.has(linkType)) {
-            properties.set(rdfs.comment, {
-                valueShape: {termType: 'Literal'},
-            });
-        }
-        return {properties};
-    }
+                const connections: Reactodia.MetadataCanConnect[] = [];
+                const addConnections = (
+                    types: readonly Reactodia.ElementTypeIri[],
+                    allOutLinks: readonly Reactodia.LinkTypeIri[],
+                    allInLinks: readonly Reactodia.LinkTypeIri[]
+                ) => {
+                    const outLinks = linkType
+                        ? allOutLinks.filter(type => type === linkType)
+                        : allOutLinks;
+                    const inLinks = linkType
+                        ? allInLinks.filter(type => type === linkType)
+                        : allInLinks;
+                    if (types.length > 0 && (outLinks.length > 0 || inLinks.length > 0)) {
+                        connections.push({targetTypes: new Set(types), outLinks, inLinks});
+                    }
+                };
 
-    async filterConstructibleTypes(
-        types: ReadonlySet<Reactodia.ElementTypeIri>,
-        options: { readonly signal?: AbortSignal }
-    ): Promise<ReadonlySet<Reactodia.ElementTypeIri>> {
-        await Reactodia.delay(SIMULATED_DELAY, {signal: options.signal});
-        return new Set(Array.from(types).filter(type => this.editableTypes.has(type)));
+                if (hasType(source, owl.Class)) {
+                    if (hasType(target, owl.Class)) {
+                        addConnections([owl.Class], [rdfs.subClassOf], [rdfs.subClassOf]);
+                    }
+
+                    const targetPropertyTypes = this.propertyTypes.filter(type => hasType(target, type));
+                    if (targetPropertyTypes.length > 0) {
+                        addConnections(targetPropertyTypes, [], [rdfs.domain, rdfs.range]);
+                    }
+                }
+
+                const sourcePropertyTypes = this.propertyTypes.filter(type => hasType(source, type));
+                if (sourcePropertyTypes.length > 0) {
+                    for (const type of sourcePropertyTypes) {
+                        if (hasType(target, type)) {
+                            addConnections([type], [rdfs.subPropertyOf], [rdfs.subPropertyOf]);
+                        }
+                    }
+
+                    if (hasType(target, owl.Class)) {
+                        addConnections([owl.Class], [rdfs.domain, rdfs.range], []);
+                    }
+                }
+
+                return connections;
+            },
+            canModifyEntity: async (entity, {signal}) => {
+                await Reactodia.delay(SIMULATED_DELAY, {signal});
+                const editable = entity.types.some(type => this.editableTypes.has(type));
+                return {
+                    canChangeIri: entity.types.includes(owl.Class),
+                    canEdit: editable,
+                    canDelete: editable,
+                };
+            },
+            canModifyRelation: async (link, source, target, {signal}) => {
+                await Reactodia.delay(SIMULATED_DELAY, {signal});
+                switch (link.linkTypeId) {
+                    case rdfs.domain:
+                    case rdfs.range:
+                    case rdfs.subClassOf:
+                    case rdfs.subPropertyOf: {
+                        return {
+                            canChangeType: true,
+                            canEdit: this.editableRelations.has(link.linkTypeId),
+                            canDelete: true,
+                        };
+                    }
+                    default: {
+                        return {};
+                    }
+                }
+            },
+            getEntityShape: async (types, {signal}) => {
+                await Reactodia.delay(SIMULATED_DELAY, {signal});
+                const properties = new Map<Reactodia.PropertyTypeIri, Reactodia.MetadataPropertyShape>();
+                if (types.some(type => this.editableTypes.has(type))) {
+                    properties.set(rdfs.comment, {
+                        valueShape: {termType: 'Literal'},
+                    });
+                    properties.set(Reactodia.rdfs.label, {
+                        valueShape: {termType: 'Literal'},
+                    });
+                    properties.set(Reactodia.schema.thumbnailUrl, {
+                        valueShape: {termType: 'NamedNode'},
+                        maxCount: 1,
+                    });
+                    properties.set(rdfs.seeAlso, {
+                        valueShape: {termType: 'NamedNode'},
+                        maxCount: 1,
+                    });
+                }
+                return {
+                    extraProperty: {
+                        valueShape: {termType: 'Literal'},
+                    },
+                    properties,
+                };
+            },
+            getRelationShape: async (linkType, {signal}) => {
+                await Reactodia.delay(SIMULATED_DELAY, {signal: signal});
+                const properties = new Map<Reactodia.PropertyTypeIri, Reactodia.MetadataPropertyShape>();
+                if (this.editableRelations.has(linkType)) {
+                    properties.set(rdfs.comment, {
+                        valueShape: {termType: 'Literal'},
+                    });
+                }
+                return {properties};
+            },
+            filterConstructibleTypes: async (types, {signal}) => {
+                await Reactodia.delay(SIMULATED_DELAY, {signal: signal});
+                return new Set(Array.from(types).filter(type => this.editableTypes.has(type)));
+            }
+        });
     }
 }
 

--- a/examples/sparql.tsx
+++ b/examples/sparql.tsx
@@ -73,13 +73,14 @@ function SparqlExample() {
                 ]}
                 languages={[
                     {code: 'de', label: 'Deutsch'},
-                    {code: 'en', label: 'english'},
-                    {code: 'es', label: 'español'},
-                    {code: 'fr', label: 'français'},
-                    {code: 'ja', label: '日本語'},
+                    {code: 'en', label: 'English'},
+                    {code: 'es', label: 'Español'},
+                    {code: 'fr', label: 'Français'},
                     {code: 'hi', label: 'हिन्दी'},
+                    {code: 'it', label: 'Italiano'},
+                    {code: 'ja', label: '日本語'},
                     {code: 'pt', label: 'português'},
-                    {code: 'ru', label: 'русский'},
+                    {code: 'ru', label: 'Русский'},
                     {code: 'zh', label: '汉语'},
                 ]}
             />

--- a/examples/stressTest.tsx
+++ b/examples/stressTest.tsx
@@ -82,9 +82,7 @@ function createLayout(factory: Reactodia.Rdf.DataFactory, options: {
     const nodeType = factory.namedNode('urn:test:Node');
     const linkType = factory.namedNode('urn:test:link');
 
-    const makeNodeIri = (n: number) => factory.namedNode(
-        `urn:test:n:${n}` as Reactodia.ElementIri
-    );
+    const makeNodeIri = (n: number) => factory.namedNode(`urn:test:n:${n}`);
 
     const elementIris: Reactodia.ElementIri[] = [];
     const quads: Reactodia.Rdf.Quad[] = [];

--- a/examples/styleCustomization.tsx
+++ b/examples/styleCustomization.tsx
@@ -36,13 +36,13 @@ function StyleCustomizationExample() {
         <Reactodia.Workspace ref={onMount}
             defaultLayout={defaultLayout}
             typeStyleResolver={types => {
-                if (types.indexOf('http://www.w3.org/2000/01/rdf-schema#Class') !== -1) {
+                if (types.includes('http://www.w3.org/2000/01/rdf-schema#Class')) {
                     return {icon: CERTIFICATE_ICON, iconMonochrome: true};
-                } else if (types.indexOf('http://www.w3.org/2002/07/owl#Class') !== -1) {
+                } else if (types.includes('http://www.w3.org/2002/07/owl#Class')) {
                     return {icon: CERTIFICATE_ICON, iconMonochrome: true};
-                } else if (types.indexOf('http://www.w3.org/2002/07/owl#ObjectProperty') !== -1) {
+                } else if (types.includes('http://www.w3.org/2002/07/owl#ObjectProperty')) {
                     return {icon: COG_ICON, iconMonochrome: true};
-                } else if (types.indexOf('http://www.w3.org/2002/07/owl#DatatypeProperty') !== -1) {
+                } else if (types.includes('http://www.w3.org/2002/07/owl#DatatypeProperty')) {
                     return {color: '#00b9f2'};
                 } else {
                     return undefined;
@@ -155,7 +155,6 @@ const DoubleArrowLinkTemplate: Reactodia.LinkTemplate = {
         width: 20,
         height: 12,
     },
-    spline: 'smooth',
     renderLink: props => (
         <Reactodia.DefaultLink {...props}
             pathProps={{stroke: '#747da8', strokeWidth: 2}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,7 @@
         "clsx": "^2.1.1",
         "d3-color": "^3.1.0",
         "file-saver": "^2.0.5",
-        "n3": "^1.23.1",
-        "webcola": "~3.3.8"
+        "n3": "^1.23.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.21.0",
@@ -51,6 +50,7 @@
         "typescript-eslint": "^8.25.0",
         "use-sync-external-store": "^1.4.0",
         "vitest": "^3.0.9",
+        "webcola": "~3.3.8",
         "webpack": "^5.98.0",
         "webpack-cli": "^6.0.1",
         "webpack-dev-middleware": "^7.4.2"
@@ -3643,12 +3643,14 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
       "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/d3-drag": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.5.tgz",
       "integrity": "sha512-rD1ohlkKQwMZYkQlYVCrSFxsWPzI97+W+PaEIBNTMxRuxz9RF0Hi5nJWHGVJ3Om9d2fRTe1yOBINJyy/ahV95w==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-dispatch": "1",
@@ -3659,12 +3661,14 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.2.tgz",
       "integrity": "sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/d3-timer": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
       "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/data-view-buffer": {
@@ -9424,6 +9428,7 @@
       "version": "3.3.9",
       "resolved": "https://registry.npmjs.org/webcola/-/webcola-3.3.9.tgz",
       "integrity": "sha512-hjE23yiRU+7AGajxuDdUDW8txyMVgXHCW71erA0UVKYx0lruqs1o4QFQ0OSpSdNS6wlAwgk0IPxhuEiQq1MXfQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "d3-dispatch": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "clsx": "^2.1.1",
     "d3-color": "^3.1.0",
     "file-saver": "^2.0.5",
-    "n3": "^1.23.1",
-    "webcola": "~3.3.8"
+    "n3": "^1.23.1"
   },
   "peerDependencies": {
     "react": "^17.0.2 || ^18 || ^19",
@@ -84,6 +83,7 @@
     "typescript-eslint": "^8.25.0",
     "use-sync-external-store": "^1.4.0",
     "vitest": "^3.0.9",
+    "webcola": "~3.3.8",
     "webpack": "^5.98.0",
     "webpack-cli": "^6.0.1",
     "webpack-dev-middleware": "^7.4.2"

--- a/src/coreUtils/hotkey.ts
+++ b/src/coreUtils/hotkey.ts
@@ -92,7 +92,7 @@ export function formatHotkey(ast: HotkeyAst): string {
         result += 'Ctrl+';
     }
     if (modifiers & HotkeyModifier.Meta) {
-        result += '⌘+';
+        result += IsMac ? '⌘+' : 'Meta+';
     }
     if (modifiers & HotkeyModifier.Alt) {
         result += 'Alt+';

--- a/src/coreUtils/i18n.tsx
+++ b/src/coreUtils/i18n.tsx
@@ -124,6 +124,15 @@ export interface Translation {
         fallbackIri: string,
         language: string
     ): string;
+
+    /**
+     * Formats IRI to display in the UI:
+     *   - usual IRIs are enclosed in `<IRI>`;
+     *   - anonymous element IRIs displayed as `(blank node)`.
+     *
+     * @deprecated Use {@link DataLocaleProvider.formatIri} instead.
+     */
+    formatIri(iri: string): string;
 }
 
 /**

--- a/src/diagram/canvasApi.ts
+++ b/src/diagram/canvasApi.ts
@@ -110,7 +110,8 @@ export interface CanvasApi {
      */
     zoomToFitRect(paperRect: Rect, options?: ViewportOptions): Promise<void>;
     /**
-     * Exports the diagram as a serialized SVG document (XML text content).
+     * Exports the diagram as a serialized into text SVG document
+     * with `<foreignObject>` HTML layers inside.
      *
      * Exported SVG document would include all diagram content as well as every CSS rule
      * which applies to any DOM element from the diagram content.

--- a/src/diagram/elementLayer.tsx
+++ b/src/diagram/elementLayer.tsx
@@ -441,8 +441,6 @@ function computeIsBlurred(element: Element, view: SharedCanvasState): boolean {
  * set to the same values as the target element to be able to layout decorations
  * via CSS.
  *
- * **Unstable**: this feature may change in the future.
- *
  * @category Components
  */
 export function ElementDecoration(props: {

--- a/src/diagram/linkLayer.tsx
+++ b/src/diagram/linkLayer.tsx
@@ -30,7 +30,6 @@ enum UpdateRequest {
     All,
 }
 
-/** @hidden */
 interface MeasurableLabel {
     readonly owner: Link;
     measureBounds(): Rect | undefined;

--- a/src/diagram/locale.tsx
+++ b/src/diagram/locale.tsx
@@ -6,6 +6,7 @@ import {
     LabelLanguageSelector, Translation, TranslationKey, TranslationBundle, TranslationContext,
 } from '../coreUtils/i18n';
 
+import { isEncodedBlank } from '../data/model';
 import * as Rdf from '../data/rdf/rdfModel';
 
 export const DefaultTranslationBundle: TranslationBundle = DefaultBundle;
@@ -68,6 +69,13 @@ export class DefaultTranslation implements Translation {
     ): string {
         const label = labels ? this.selectLabel(labels, language) : undefined;
         return resolveLabel(label, fallbackIri);
+    }
+
+    formatIri(iri: string): string {
+        if (isEncodedBlank(iri)) {
+            return '(blank node)';
+        }
+        return `<${iri}>`;
     }
 }
 

--- a/src/diagram/paper.tsx
+++ b/src/diagram/paper.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Component, CSSProperties } from 'react';
 
 import { Cell, LinkVertex } from './elements';
 import { Vector } from './geometry';
@@ -16,7 +15,7 @@ export interface PaperProps {
 
 const CLASS_NAME = 'reactodia-paper';
 
-export class Paper extends Component<PaperProps> {
+export class Paper extends React.Component<PaperProps> {
     render() {
         const {paperTransform, children} = this.props;
         const {width, height, scale, paddingX, paddingY} = paperTransform;
@@ -26,7 +25,7 @@ export class Paper extends Component<PaperProps> {
         // using padding instead of margin in combination with setting width and height
         // on .paper element to avoid "over-constrained" margins, see an explanation here:
         // https://stackoverflow.com/questions/11695354
-        const style: CSSProperties = {
+        const style: React.CSSProperties = {
             width: scaledWidth + paddingX,
             height: scaledHeight + paddingY,
             marginLeft: paddingX,
@@ -120,6 +119,7 @@ export interface PaperTransform {
  * Props for {@link HtmlPaperLayer} component.
  *
  * @see {@link HtmlPaperLayer}
+ * @hidden
  */
 export interface HtmlPaperLayerProps extends React.HTMLProps<HTMLDivElement> {
     paperTransform: PaperTransform;
@@ -132,6 +132,7 @@ export interface HtmlPaperLayerProps extends React.HTMLProps<HTMLDivElement> {
  * **Unstable**: this component will likely change in the future.
  *
  * @category Components
+ * @hidden
  */
 export function HtmlPaperLayer(props: HtmlPaperLayerProps) {
     const {paperTransform, layerRef, style, children, ...otherProps} = props;
@@ -160,6 +161,7 @@ export function HtmlPaperLayer(props: HtmlPaperLayerProps) {
  * Props for {@link SvgPaperLayer} component.
  *
  * @see {@link SvgPaperLayer}
+ * @hidden
  */
 export interface SvgPaperLayerProps extends React.HTMLProps<SVGSVGElement> {
     paperTransform: PaperTransform;
@@ -172,6 +174,7 @@ export interface SvgPaperLayerProps extends React.HTMLProps<SVGSVGElement> {
  * **Unstable**: this component will likely change in the future.
  *
  * @category Components
+ * @hidden
  */
 export function SvgPaperLayer(props: SvgPaperLayerProps) {
     const {layerRef, paperTransform, style, children, ...otherProps} = props;

--- a/src/diagram/renderingState.ts
+++ b/src/diagram/renderingState.ts
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { multimapAdd, multimapDelete } from '../coreUtils/collections';
 import { Events, EventObserver, EventSource, PropertyChange } from '../coreUtils/events';
 import {
-    type HotkeyAst, sameHotkeyAst, hashHotkeyAst, eventToHotkeyAst,
+    type HotkeyAst, formatHotkey, sameHotkeyAst, hashHotkeyAst, eventToHotkeyAst,
 } from '../coreUtils/hotkey';
 import { Debouncer } from '../coreUtils/scheduler';
 
@@ -408,6 +408,12 @@ export class MutableRenderingState implements RenderingState {
 
     listenHotkey(ast: HotkeyAst, handler: () => void): () => void {
         multimapAdd(this.hotkeyHandlers, ast, handler);
+        if (this.hotkeyHandlers.get(ast)!.size === 2) {
+            console.warn(
+                'Reactodia: registered multiple handlers for the same hotkey ' +
+                `"${formatHotkey(ast)}" but only the first one will run if triggered.`
+            );
+        }
         return () => {
             multimapDelete(this.hotkeyHandlers, ast, handler);
         };
@@ -423,6 +429,8 @@ export class MutableRenderingState implements RenderingState {
             for (const handler of handlers) {
                 e.preventDefault();
                 handler();
+                // Use only the first handler and skip the rest
+                break;
             }
         }
     }

--- a/src/widgets/toolbarAction.tsx
+++ b/src/widgets/toolbarAction.tsx
@@ -16,7 +16,6 @@ import { AuthoringState } from '../editor/authoringState';
 import { DropdownMenuItem, useInsideDropdown } from './utility/dropdown';
 
 import { useWorkspace } from '../workspace/workspaceContext';
-import { EventObserver } from '../workspace';
 
 const CLASS_NAME = 'reactodia-toolbar-action';
 

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -85,6 +85,7 @@ export {
     LinkLabel, LinkLabelProps,
     LinkVertices, LinkVerticesProps,
 } from './diagram/linkLayer';
+export { DefaultLinkRouter, DefaultLinkRouterOptions } from './diagram/linkRouter';
 export { type DiagramModel, DiagramModelEvents, GraphStructure } from './diagram/model';
 export {
     type PaperTransform, paneTopLeft, totalPaneSize,
@@ -177,7 +178,7 @@ export {
     ViewportDock, ViewportDockProps, DockDirection,
 } from './widgets/utility/viewportDock';
 export { ClassTree, ClassTreeProps } from './widgets/classTree';
-export { Canvas, CanvasProps } from './widgets/canvas';
+export { Canvas, CanvasProps, TypedElementResolver } from './widgets/canvas';
 export {
     ConnectionsMenu, ConnectionsMenuProps, ConnectionsMenuCommands,
     PropertySuggestionHandler, PropertySuggestionParams, PropertyScore,

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -23,7 +23,7 @@ export * from './data/dataProvider';
 export * from './data/model';
 export {
     MetadataProvider, MetadataCanConnect, MetadataCanModifyEntity, MetadataCanModifyRelation,
-    MetadataEntityShape, MetadataRelationShape, MetadataPropertyShape, EmptyMetadataProvider,
+    MetadataEntityShape, MetadataRelationShape, MetadataPropertyShape, BaseMetadataProvider,
 } from './data/metadataProvider';
 export {
     ValidationProvider, ValidationEvent, ValidationResult, ValidatedElement, ValidatedLink,

--- a/src/workspace/workspace.tsx
+++ b/src/workspace/workspace.tsx
@@ -520,6 +520,10 @@ export function useLoadedWorkspace(
             (async () => {
                 const task = context.overlay.startTask();
                 try {
+                    // Move execution into a microtask to avoid React warnings
+                    // when calling RenderingState.syncUpdate()
+                    await Promise.resolve();
+
                     await latestOnLoad({context, signal: controller.signal});
                 } catch (err) {
                     if (!controller.signal.aborted) {

--- a/styles/utility/_dropdown.scss
+++ b/styles/utility/_dropdown.scss
@@ -81,6 +81,11 @@
     border-bottom-right-radius: theme.$button-border-radius;
   }
 
+  .reactodia-dropdown--down & ~ & {
+    margin-top: calc(-1 * theme.$button-border-width);
+    border-top-color: theme.$button-default-border-color;
+  }
+
   .reactodia-dropdown--up &:first-child {
     border-bottom-right-radius: theme.$button-border-radius;
   }
@@ -90,10 +95,11 @@
     border-top-right-radius: theme.$button-border-radius;
   }
 
-  & ~ & {
-    margin-top: calc(-1 * theme.$button-border-width);
-    border-top-color: theme.$button-default-border-color;
+  .reactodia-dropdown--up & ~ & {
+    margin-bottom: calc(-1 * theme.$button-border-width);
+    border-bottom-color: theme.$button-default-border-color;
   }
+
   &--disabled, &--disabled:hover {
     color: theme.$button-default-color;
     background-color: theme.$input-background-color-disabled;


### PR DESCRIPTION
* Change `EmptyMetadataProvider` into `BaseMetadataProvider` which auto-delegates to passed partial provider methods;
* Warn on multiple registered hotkeys with the same keys and only run the first one;
* Allow to full override property editor for relations the same way as for entities via `propertyEditor`;
* Move `useLoadedWorkspace()` callback execution into a microtask to avoid React warnings when calling `syncUpdate()`;
* Export `DefaultLinkRouter`, `TypedElementResolver`;
* Fix item borders for up-expanded dropdown menus;
* Deprecate `Translation.formatIri()` instead of full removal;
* Clarify JSDoc for some components;
* Update examples;