### PR TITLE
Fix tab-order, focusability and auto-focus for modal dialogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 #### 🐛 Fixed
 - Exclude collapsed `DropdownMenu` and `UnifiedSearch` content from Tab-navigation.
 - Exclude canvas elements from Tab-navigation unless the element is only one selected.
+- Block canvas interacton (including Tab-navigation) when displaying a blocking modal overlay i.e. an overlay task or viewport-centered dialog.
 - Fix Tab-navigation order on `DefaultWorkspace` and `ClassicWorkspace` to generally follow top-to-bottom then left-to-right when moving focus.
 
 ## [0.35.0] - 2026-06-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Exclude canvas elements from Tab-navigation unless the element is only one selected.
 - Block canvas interacton (including Tab-navigation) when displaying a blocking modal overlay i.e. an overlay task or viewport-centered dialog.
 - Fix Tab-navigation order on `DefaultWorkspace` and `ClassicWorkspace` to generally follow top-to-bottom then left-to-right when moving focus.
+- Auto-focus within dialogs by default (via `autoFocus` prop) to avoid losing focus when a dialog displayed in the modal overlay or opened by already unmounted trigger element.
 
 ## [0.35.0] - 2026-06-21
 #### 🚀 New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Reactodia will be documented in this document.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+#### 🐛 Fixed
+- Exclude collapsed `DropdownMenu` and `UnifiedSearch` content from Tab-navigation.
+- Exclude canvas elements from Tab-navigation unless the element is only one selected.
+- Fix Tab-navigation order on `DefaultWorkspace` and `ClassicWorkspace` to generally follow top-to-bottom then left-to-right when moving focus.
 
 ## [0.35.0] - 2026-06-21
 #### 🚀 New Features

--- a/i18n/i18n.schema.json
+++ b/i18n/i18n.schema.json
@@ -231,6 +231,7 @@
       "$ref": "#/$defs/Group",
       "additionalProperties": false,
       "properties": {
+        "dialog_close.title": { "$ref": "#/$defs/Value" },
         "multiple_tasks_in_progress": { "$ref": "#/$defs/Value" },
         "unknown_error": { "$ref": "#/$defs/Value" }
       }

--- a/i18n/translations/en.reactodia-translation.json
+++ b/i18n/translations/en.reactodia-translation.json
@@ -160,6 +160,7 @@
     "style_underline.title": "Underline"
   },
   "overlay_controller": {
+    "dialog_close.title": "Close",
     "multiple_tasks_in_progress": "Multiple tasks are in progress",
     "unknown_error": "Unknown error occurred"
   },

--- a/src/coreUtils/dom.ts
+++ b/src/coreUtils/dom.ts
@@ -90,3 +90,23 @@ export function findParentWithin(
     }
     return undefined;
 }
+
+const FOCUSABLE_SELECTORS: readonly string[] = [
+    '[data-reactodia-autofocus]',
+    '[autofocus]',
+    'input:not(disabled), textarea:not(disabled), button:not(disabled), select:not(disabled), a[href], details > summary',
+];
+
+export function findAutoFocusable(parent: HTMLElement): HTMLElement | undefined {
+    const activeElement = document.activeElement;
+    if (parent.contains(activeElement)) {
+        return activeElement instanceof HTMLElement ? activeElement : undefined;
+    }
+    for (const selector of FOCUSABLE_SELECTORS) {
+        const target = parent.querySelector(selector);
+        if (target instanceof HTMLElement) {
+            return target;
+        }
+    }
+    return undefined;
+}

--- a/src/diagram/canvasArea.tsx
+++ b/src/diagram/canvasArea.tsx
@@ -6,6 +6,7 @@ import { delay } from '../coreUtils/async';
 import { ColorSchemeApi } from '../coreUtils/colorScheme';
 import { findParentWithin } from '../coreUtils/dom';
 import { EventObserver, Events, EventSource } from '../coreUtils/events';
+import { useObservedProperty } from '../coreUtils/hooks';
 
 import {
     Paper, PaperProps, type ScaleDefaults, type PaperPointerOperation, wheelToScaleDeltaDefault,
@@ -99,6 +100,12 @@ export function CanvasArea(props: {
         return () => controller.stopListening();
     }, []);
 
+    const interactionBlocked = useObservedProperty(
+        renderingState.events,
+        'changeInteractionBlocked',
+        () => renderingState.interactionBlocked
+    );
+
     const style = {
         '--reactodia-canvas-animation-duration': graphAnimations.duration === undefined
             ? undefined : `${graphAnimations.duration}ms`,
@@ -168,6 +175,9 @@ export function CanvasArea(props: {
                         />
                     </>
                 )}
+                paneProps={{
+                    inert: interactionBlocked ? '' : undefined,
+                } as React.HTMLProps<HTMLDivElement>}
                 watermark={
                     watermarkSvg ? (
                         <a href={watermarkUrl} target='_blank' rel='noreferrer'>

--- a/src/diagram/elementLayer.tsx
+++ b/src/diagram/elementLayer.tsx
@@ -350,7 +350,7 @@ class OverlaidElement extends React.Component<OverlaidElementProps> {
                     style={style}
                     // set `element-id` to translate mouse events to paper
                     data-element-id={element.id}
-                    tabIndex={0}
+                    tabIndex={templateProps.onlySelected ? 0 : -1}
                     ref={
                         /* For compatibility with React 19 typings */
                         this.elementRef as React.RefObject<HTMLDivElement>

--- a/src/diagram/renderingState.ts
+++ b/src/diagram/renderingState.ts
@@ -45,6 +45,10 @@ export interface RenderingStateEvents {
         readonly layer: RenderingLayer;
     };
     /**
+     * Triggered on {@link RenderingState.interactionBlocked} property change.
+     */
+    changeInteractionBlocked: PropertyChange<RenderingState, boolean>;
+    /**
      * Triggered on {@link RenderingState.getLinkTemplates} property change.
      */
     changeLinkTemplates: {
@@ -134,6 +138,10 @@ export interface RenderingState extends SizeProvider {
      * Shared state for all canvases rendering the same model.
      */
     readonly shared: SharedCanvasState;
+    /**
+     * Whether any canvas interaction is blocked by a modal overlay.
+     */
+    get interactionBlocked(): boolean;
     /**
      * Request to synchronously render the canvas, performing any
      * previously deferred updates.
@@ -231,6 +239,8 @@ export class MutableRenderingState implements RenderingState {
         hashHotkeyAst, sameHotkeyAst
     );
 
+    private _interactionBlocks = 0;
+
     readonly shared: SharedCanvasState;
 
     /** @hidden */
@@ -279,6 +289,19 @@ export class MutableRenderingState implements RenderingState {
         this.listener.stopListening();
         this.layerUpdater.dispose();
         this.cancelOnLayerUpdate(RenderingLayer.LinkRoutes, this.updateRoutings);
+    }
+
+    get interactionBlocked(): boolean {
+        return this._interactionBlocks > 0;
+    }
+
+    changeInteractionBlocks(change: 1 | -1): void {
+        const previous = this._interactionBlocks !== 0;
+        this._interactionBlocks += change;
+        const interactionBlocked = this._interactionBlocks !== 0;
+        if (interactionBlocked !== previous) {
+            this.source.trigger('changeInteractionBlocked', {previous, source: this});
+        }
     }
 
     syncUpdate() {

--- a/src/editor/overlayController.tsx
+++ b/src/editor/overlayController.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import cx from 'clsx';
 
 import { delay } from '../coreUtils/async';
 import { Events, EventObserver, EventSource, PropertyChange } from '../coreUtils/events';
@@ -343,14 +344,12 @@ export class OverlayController {
             this.hideDialog();
         }
 
-        const previousDialog = this._openedDialog;
         const openedDialog: OverlayDialog = {
             target,
             knownType: dialogType,
             holdSelection,
             onClose,
         };
-        this._openedDialog = openedDialog;
 
         const canvas = this.view.findAnyCanvas();
         const breakpoint = readOverlayProperty(
@@ -378,6 +377,7 @@ export class OverlayController {
         const onHide = () => this.hideDialog();
         if (target && !isSmallViewport) {
             this.setDialog(
+                openedDialog,
                 <CanvasPlaceAt layer='overElements'>
                     <Dialog {...styleWithDefaults}
                         target={
@@ -393,6 +393,7 @@ export class OverlayController {
             );
         } else {
             this.setDialog(
+                openedDialog,
                 <ViewportDialog {...styleWithDefaults}
                     mode={isSmallViewport ? 'fillViewport' : 'centered'}
                     onResize={onResize}
@@ -401,11 +402,6 @@ export class OverlayController {
                 </ViewportDialog>
             );
         }
-        
-        this.source.trigger('changeOpenedDialog', {
-            source: this,
-            previous: previousDialog,
-        });
     }
 
     /**
@@ -416,18 +412,25 @@ export class OverlayController {
     hideDialog() {
         if (this._openedDialog) {
             const previous = this._openedDialog;
-            this._openedDialog = undefined;
             previous.onClose?.();
-            this.setDialog(null);
-            this.source.trigger('changeOpenedDialog', {source: this, previous});
+            this.setDialog(undefined, null);
         }
     }
 
-    private setDialog(dialog: React.ReactElement | null): void {
+    private setDialog(
+        openedDialog: OverlayDialog | undefined,
+        dialog: React.ReactElement | null
+    ): void {
         const internalApi = withInternalApi(this)[OverlayInternalApi];
+        const previousDialog = this._openedDialog;
         const previous = internalApi.dialog;
+        this._openedDialog = openedDialog;
         internalApi.dialog = dialog;
         this.internalSource.trigger('changeDialog', {previous, source: this});
+        this.source.trigger('changeOpenedDialog', {
+            source: this,
+            previous: previousDialog,
+        });
     }
 }
 
@@ -565,11 +568,11 @@ function LoadingWidget(props: { spinnerProps: SpinnerProps }) {
         y: size.height / 2,
     };
     return (
-        <div className='reactodia-loading-widget'>
+        <ViewportOverlay className='reactodia-loading-widget'>
             <svg width={size.width} height={size.height}>
                 <Spinner position={position} {...spinnerProps} />
             </svg>
-        </div>
+        </ViewportOverlay>
     );
 }
 
@@ -592,12 +595,32 @@ function ViewportDialog(props: DialogProps) {
         [viewportSize, margin]
     );
     return (
-        <div ref={overlayRef}
+        <ViewportOverlay innerRef={overlayRef}
             className='reactodia-viewport-dialog-overlay'>
             <Dialog {...props}
                 dock='e'
                 maxSize={maxSize}
             />
+        </ViewportOverlay>
+    );
+}
+
+function ViewportOverlay(props: {
+    innerRef?: React.RefObject<HTMLDivElement>;
+    className?: string;
+    children: React.ReactNode;
+}) {
+    const {innerRef, className, children} = props;
+    const {canvas} = useCanvas();
+    const renderingState = canvas.renderingState as MutableRenderingState;
+    React.useLayoutEffect(() => {
+        renderingState.changeInteractionBlocks(1);
+        return () => renderingState.changeInteractionBlocks(-1);
+    }, [renderingState]);
+    return (
+        <div ref={innerRef}
+            className={cx('reactodia-viewport-overlay', className)}>
+            {children}
         </div>
     );
 }

--- a/src/editor/overlayController.tsx
+++ b/src/editor/overlayController.tsx
@@ -375,6 +375,7 @@ export class OverlayController {
             this.dialogSettingsProvider.persistDialogSize(openedDialog, size);
         };
         const onHide = () => this.hideDialog();
+        const closeTitle = this.translation.text('overlay_controller.dialog_close.title');
         if (target && !isSmallViewport) {
             this.setDialog(
                 openedDialog,
@@ -386,7 +387,8 @@ export class OverlayController {
                             target
                         }
                         onResize={onResize}
-                        onHide={onHide}>
+                        onHide={onHide}
+                        closeTitle={closeTitle}>
                         {content}
                     </Dialog>
                 </CanvasPlaceAt>
@@ -397,7 +399,8 @@ export class OverlayController {
                 <ViewportDialog {...styleWithDefaults}
                     mode={isSmallViewport ? 'fillViewport' : 'centered'}
                     onResize={onResize}
-                    onHide={onHide}>
+                    onHide={onHide}
+                    closeTitle={closeTitle}>
                     {content}
                 </ViewportDialog>
             );

--- a/src/paper/paper.tsx
+++ b/src/paper/paper.tsx
@@ -34,6 +34,7 @@ export interface PaperProps {
     pageSize: Size;
     contentBounds: Rect;
     renderLayers: (transform: PaperTransform) => React.ReactNode;
+    paneProps?: React.HTMLProps<HTMLDivElement>;
     watermark?: React.ReactNode;
     children?: React.ReactNode;
 }
@@ -149,7 +150,7 @@ export class Paper extends React.Component<PaperProps, State> {
     render() {
         const {
             className, style, showScrollbars, panOnTouch = true,
-            onContextMenu, onKeyDown, onKeyUp, renderLayers, watermark, children,
+            onContextMenu, onKeyDown, onKeyUp, renderLayers, paneProps, watermark, children,
         } = this.props;
         const {transform, mounted} = this.state;
         const {width, height, scale, paddingX, paddingY} = transform;
@@ -180,7 +181,8 @@ export class Paper extends React.Component<PaperProps, State> {
                 tabIndex={0}
                 onKeyDown={onKeyDown}
                 onKeyUp={onKeyUp}>
-                <div className={`${CLASS_NAME}__pane`}
+                <div {...paneProps}
+                    className={`${CLASS_NAME}__pane`}
                     ref={this.paneRef}
                     onPointerDown={this.onAreaPointerDown}>
                     <div className={`${CLASS_NAME}__layers`}

--- a/src/widgets/connectionsMenu/connectionsMenu.tsx
+++ b/src/widgets/connectionsMenu/connectionsMenu.tsx
@@ -509,6 +509,7 @@ class ConnectionsMenuInner extends React.Component<ConnectionsMenuInnerProps, Me
                     inputProps={{
                         name: 'reactodia-connection-menu-filter',
                         placeholder: t.textOptional('connections_menu.input.placeholder'),
+                        'data-reactodia-autofocus': true,
                     }}>
                     {this.renderSortSwitches()}
                 </SearchInput>

--- a/src/widgets/dialog.tsx
+++ b/src/widgets/dialog.tsx
@@ -104,6 +104,7 @@ export class Dialog extends React.Component<DialogProps, State> {
     private unsubscribeFromTarget: Unsubscribe | undefined = undefined;
     private readonly listener = new EventObserver();
 
+    private root = React.createRef<HTMLDivElement>();
     private updateAll = () => this.forceUpdate();
 
     private startSize: Vector | undefined;
@@ -306,7 +307,7 @@ export class Dialog extends React.Component<DialogProps, State> {
         };
 
         return (
-            <div
+            <div ref={this.root}
                 className={cx(
                     CLASS_NAME,
                     target ? 'reactodia-dialog--attached' : undefined,

--- a/src/widgets/dialog.tsx
+++ b/src/widgets/dialog.tsx
@@ -1,6 +1,7 @@
 import cx from 'clsx';
 import * as React from 'react';
 
+import { findAutoFocusable } from '../coreUtils/dom';
 import { EventObserver, Unsubscribe } from '../coreUtils/events';
 
 import { CanvasContext } from '../diagram/canvasApi';
@@ -16,6 +17,7 @@ export interface DialogProps extends DialogStyleProps {
     onResize?: (size: Size) => void;
     onHide: () => void;
     mode?: 'centered' | 'fillViewport';
+    closeTitle?: string;
     children: React.ReactNode;
 }
 
@@ -61,6 +63,17 @@ export interface DialogStyleProps {
      * @default true
      */
     closable?: boolean;
+    /**
+     * Whether the dialog should auto-focus on first focusable child.
+     *
+     * If exists, the auto-focus focuses on elements with `data-reactodia-autofocus`
+     * attribute, next with `autofocus` attibute otherwise on first
+     * [tab-indexable](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/tabindex)
+     * child.
+     *
+     * @default true
+     */
+    autoFocus?: boolean;
     /**
      * Dock direction for the dialog from the {@link DialogProps.target target}
      * point of view:
@@ -116,11 +129,16 @@ export class Dialog extends React.Component<DialogProps, State> {
 
     componentDidMount() {
         const {canvas, model} = this.context;
+        const {autoFocus = true} = this.props;
         this.listener.listen(model.events, 'changeLanguage', this.updateAll);
         this.listener.listen(canvas.events, 'changeTransform', this.updateAll);
         this.listenToTarget(this.props.target);
         if (this.props.target) {
             this.focusOn();
+        }
+        if (autoFocus && this.root.current) {
+            const autoFocusable = findAutoFocusable(this.root.current);
+            autoFocusable?.focus();
         }
     }
 
@@ -294,6 +312,7 @@ export class Dialog extends React.Component<DialogProps, State> {
             caption,
             resizableBy: baseResizableBy = 'all',
             closable = true,
+            closeTitle,
         } = this.props;
 
         const resizableBy = mode === 'fillViewport' ? 'none' : baseResizableBy;
@@ -324,7 +343,7 @@ export class Dialog extends React.Component<DialogProps, State> {
                         {caption}
                     </div>
                     {closable ? (
-                        <button title='Close'
+                        <button title={closeTitle}
                             className={cx(
                                 'reactodia-btn',
                                 `${CLASS_NAME}__close-button`

--- a/src/widgets/unifiedSearch/unifiedSearch.tsx
+++ b/src/widgets/unifiedSearch/unifiedSearch.tsx
@@ -310,7 +310,8 @@ export function UnifiedSearch(props: UnifiedSearchProps) {
                     panelSize={effectiveSize}
                 />
             }>
-            <SearchContent sections={sectionsWithContext}
+            <SearchContent visible={expanded}
+                sections={sectionsWithContext}
                 activeSectionKey={activeSection.key}
                 onActivateSection={key => setActiveSection(previous => previous.switch(key))}
                 dropUp={direction === 'up'}
@@ -451,6 +452,7 @@ function SearchToggle(props: {
 }
 
 function SearchContent(props: {
+    visible: boolean;
     sections: ReadonlyArray<SectionWithContext>;
     activeSectionKey: string | undefined;
     onActivateSection: (sectionKey: string) => void;
@@ -462,7 +464,7 @@ function SearchContent(props: {
     setMaxSize: (size: Size) => void;
 }) {
     const {
-        sections, activeSectionKey, onActivateSection,
+        visible, sections, activeSectionKey, onActivateSection,
         dropUp, size, minSize, offsetForMaxSize, onResize, setMaxSize,
     } = props;
 
@@ -534,8 +536,13 @@ function SearchContent(props: {
     const sectionPanelId = (section: SectionWithContext) =>
         `reactodia-unified-search-panel-${section.key}`;
 
+    const otherProps = {
+        inert: visible ? undefined : '',
+    } as React.HTMLProps<HTMLDivElement>;
+
     return (
-        <div ref={panelRef}
+        <div {...otherProps}
+            ref={panelRef}
             className={`${CLASS_NAME}__panel`}
             style={{
                 width: size.width,

--- a/src/widgets/utility/dropdown.tsx
+++ b/src/widgets/utility/dropdown.tsx
@@ -253,7 +253,7 @@ export function DropdownMenuItem(props: DropdownMenuItemProps) {
             ref={ref}
             type='button'
             role='menuitem'
-            tabIndex={tabIndex}
+            tabIndex={tabIndex ?? -1}
             className={cx(
                 className,
                 ITEM_CLASS_NAME,

--- a/src/widgets/utility/searchInput.tsx
+++ b/src/widgets/utility/searchInput.tsx
@@ -8,10 +8,12 @@ import { Debouncer } from '../../coreUtils/scheduler';
 
 export interface SearchInputProps {
     className?: string;
-    inputProps?: React.HTMLProps<HTMLInputElement>;
+    inputProps?: React.HTMLProps<HTMLInputElement> & DataAttributes;
     store: SearchInputStore;
     children?: React.ReactNode;
 }
+
+type DataAttributes = Record<`data-${string}`, string | number | boolean | undefined | null>;
 
 const CLASS_NAME = 'reactodia-search-input';
 

--- a/src/widgets/utility/viewportDock.tsx
+++ b/src/widgets/utility/viewportDock.tsx
@@ -1,6 +1,9 @@
 import cx from 'clsx';
 import * as React from 'react';
 
+import { useObservedProperty } from '../../coreUtils/hooks';
+import { useCanvas } from '../../diagram/canvasApi';
+
 /**
  * Compass-like direction for the dock side:
  *  - `nw`: north-west (top-left)
@@ -87,14 +90,23 @@ export interface ViewportDockProps {
  */
 export function ViewportDock(props: ViewportDockProps) {
     const {dock, dockOffsetX = 0, dockOffsetY = 0, children} = props;
+    const {canvas: {renderingState}} = useCanvas();
+    const interactionBlocked = useObservedProperty(
+        renderingState.events,
+        'changeInteractionBlocked',
+        () => renderingState.interactionBlocked
+    );
     const style = {
         '--reactodia-viewport-dock-offset-x': `${dockOffsetX}px`,
         '--reactodia-viewport-dock-offset-y': `${dockOffsetY}px`,
         '--reactodia-viewport-dock-align-x': DOCK_ALIGN_X[dock],
         '--reactodia-viewport-dock-align-y': DOCK_ALIGN_Y[dock],
     } as React.CSSProperties;
+    const otherProps = {
+        inert: interactionBlocked ? '' : undefined,
+    } as React.HTMLProps<HTMLDivElement>;
     return (
-        <div
+        <div {...otherProps}
             className={cx(
                 VIEWPORT_WIDGET_CLASS,
                 DOCK_CONTAINER_CLASS[dock] ?? `${VIEWPORT_WIDGET_CLASS}--corner`

--- a/src/widgets/visualAuthoring/authoredEntityDecorator.tsx
+++ b/src/widgets/visualAuthoring/authoredEntityDecorator.tsx
@@ -141,6 +141,7 @@ export function AuthoredEntityDecorator(props: {
                 ) : null}
                 {isTemporary ? null : (
                     <InlineActions target={target}
+                        onlySelected={onlyTargetSelected}
                         state={state}
                         allActions={Boolean(inlineActions)}
                     />
@@ -199,14 +200,16 @@ function getSeverityClass(severity: ValidationSeverity): string | undefined {
 
 function InlineActions(props: {
     target: EntityElement;
+    onlySelected: boolean;
     state: AuthoredEntity | undefined;
     allActions: boolean;
 }) {
-    const {target, state, allActions} = props;
+    const {target, onlySelected, state, allActions} = props;
     const {editor} = useWorkspace();
     const t = useTranslation();
 
     const authored = useAuthoredEntity(target.data, allActions);
+    const tabIndex = onlySelected ? 0 : -1;
 
     return (
         <div className={`${CLASS_NAME}__actions`}>
@@ -218,7 +221,8 @@ function InlineActions(props: {
                         authored.canEdit
                             ? t.text('authoring_state.entity_action_edit.title')
                             : t.text('authoring_state.entity_action_edit.title_disabled')
-                    }>
+                    }
+                    tabIndex={tabIndex}>
                     {t.text('authoring_state.entity_action_edit.label')}
                 </button>
             ) : null}
@@ -230,14 +234,16 @@ function InlineActions(props: {
                         authored.canEdit
                             ? t.text('authoring_state.entity_action_delete.title')
                             : t.text('authoring_state.entity_action_delete.title_disabled')
-                    }>
+                    }
+                    tabIndex={tabIndex}>
                     {t.text('authoring_state.entity_action_delete.label')}
                 </button>
             ) : null}
             {state && state.type !== 'entityAdd' ? (
                 <button className={`${CLASS_NAME}__action ${CLASS_NAME}__action-discard`}
                     onClick={() => editor.discardChange(state)}
-                    title={t.text('authoring_state.entity_action_discard.title')}>
+                    title={t.text('authoring_state.entity_action_discard.title')}
+                    tabIndex={tabIndex}>
                     {t.text('authoring_state.entity_action_discard.label')}
                 </button>
             ) : null}

--- a/src/workspace/classicWorkspace.tsx
+++ b/src/workspace/classicWorkspace.tsx
@@ -113,9 +113,9 @@ export function ClassicWorkspace(props: ClassicWorkspaceProps) {
                         {selection === null ? null : (
                             <Selection {...selection} />
                         )}
-                        {navigator === null ? null : <Navigator dock='se' {...navigator} />}
                         {toolbar === null ? null : <ClassicToolbar dock='nw' {...toolbar} />}
                         {zoomControl === null ? null : <ZoomControl dock='sw' {...zoomControl} />}
+                        {navigator === null ? null : <Navigator dock='se' {...navigator} />}
                         {canvasWidgets}
                         {children}
                     </Canvas>

--- a/src/workspace/defaultWorkspace.tsx
+++ b/src/workspace/defaultWorkspace.tsx
@@ -271,16 +271,6 @@ export function DefaultWorkspace(props: DefaultWorkspaceProps) {
                 {halo === null ? null : <Halo {...halo} />}
                 {haloLink === null ? null : <HaloLink {...haloLink} />}
                 {selection === null ? null : <Selection {...selection} />}
-                {zoomControl === null ? null : (
-                    <ZoomControl dock='w'
-                        {...zoomControl}
-                    />
-                )}
-                {navigator === null ? null : (
-                    <Navigator dock='se'
-                        {...navigator}
-                    />
-                )}
                 <Toolbar {...mainToolbar}
                     dock={menuDock}
                     menu={menuContent}>
@@ -291,12 +281,22 @@ export function DefaultWorkspace(props: DefaultWorkspaceProps) {
                         />
                     )}
                 </Toolbar>
+                {zoomControl === null ? null : (
+                    <ZoomControl dock='w'
+                        {...zoomControl}
+                    />
+                )}
                 {actionsContent === null ? null : (
                     <Toolbar {...actionsToolbar}
                         dock={actionsToolbar?.dock ?? 'sw'}
                         menu={null}>
                         {actionsContent}
                     </Toolbar>
+                )}
+                {navigator === null ? null : (
+                    <Navigator dock='se'
+                        {...navigator}
+                    />
                 )}
                 {canvasWidgets}
                 {children}

--- a/styles/editor/_overlays.scss
+++ b/styles/editor/_overlays.scss
@@ -1,17 +1,21 @@
 @use "../mixin/zIndex";
 @use "../theme/theme";
 
-.reactodia-loading-widget {
-  left: 0;
-  right: 0;
-  top: 0;
-  bottom: 0;
-  margin: auto;
+.reactodia-viewport-overlay {
   position: absolute;
+  inset: 0;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: theme.$color-emphasis-1000;
   background-color: theme.$canvas-overlay-color;
+}
+
+.reactodia-loading-widget {
+  margin: auto;
+  color: theme.$color-emphasis-1000;
   z-index: zIndex.$loading-widget;
+}
+
+.reactodia-viewport-dialog-overlay {
+  z-index: zIndex.$viewport-dialog;
 }

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -13,7 +13,7 @@
 @forward "editor/editEntityForm";
 @forward "editor/editRelationForm";
 @forward "editor/elementSelector";
-@forward "editor/loadingWidget";
+@forward "editor/overlays";
 @forward "editor/withFetchStatus";
 
 @forward "forms/inlineDiagnostic";

--- a/styles/widgets/_dialog.scss
+++ b/styles/widgets/_dialog.scss
@@ -45,18 +45,3 @@
     }
   }
 }
-
-.reactodia-viewport-dialog-overlay {
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: 0;
-  bottom: 0;
-  z-index: zIndex.$viewport-dialog;
-
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  
-  background-color: theme.$canvas-overlay-color;
-}


### PR DESCRIPTION
* Exclude collapsed `DropdownMenu` and `UnifiedSearch` content from Tab-navigation.
* Exclude canvas elements from Tab-navigation unless the element is only one selected.
* Block canvas interacton (including Tab-navigation) when displaying a blocking modal overlay i.e. an overlay task or viewport-centered dialog.
* Fix Tab-navigation order on `DefaultWorkspace` and `ClassicWorkspace` to generally follow top-to-bottom then left-to-right when moving focus.
* Auto-focus within dialogs by default (via `autoFocus` prop) to avoid losing focus when a dialog displayed in the modal overlay or opened by already unmounted trigger element.