### PR TITLE
Fix single connection rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 #### 🐛 Fixed
 - Fix relation having changed `data` but missing from `AuthoringState` when the source or target entity becomes deleted then restored back.
 - Fix grouped relation (`RelationGroup` item) does not updating its `data` when changed by `EditorController`.
+- Fix `ConnectionsMenu` displaying no links when there is only a single incoming/outgoing relation type. (by @cristianvasquez)
 - Exclude collapsed `DropdownMenu` and `UnifiedSearch` content from Tab-navigation.
 - Exclude canvas elements from Tab-navigation unless the element is only one selected.
 - Block canvas interacton (including Tab-navigation) when displaying a blocking modal overlay i.e. an overlay task or viewport-centered dialog.

--- a/src/widgets/connectionsMenu/connectionList.tsx
+++ b/src/widgets/connectionsMenu/connectionList.tsx
@@ -25,9 +25,9 @@ export function ConnectionsList(props: {
 
     allRelatedLink: LinkTypeModel;
     onExpandLink: (chunk: LinkDataChunk) => void;
-    onMoveToFilter: ((chunk: LinkDataChunk) => void) | undefined;
+    onMoveToFilter?: (chunk: LinkDataChunk) => void;
 
-    scrolledListRef: React.RefObject<HTMLUListElement | null>;
+    scrolledListRef?: React.RefObject<HTMLUListElement | null>;
 }) {
     const {
         data, filterKey, sortMode, suggestions,

--- a/src/widgets/connectionsMenu/connectionList.tsx
+++ b/src/widgets/connectionsMenu/connectionList.tsx
@@ -77,9 +77,10 @@ export function ConnectionsList(props: {
             count: inexact && totalCount > 0 ? 'some' : totalCount,
         });
         entries.push({type: 'separator'});
-        for (const entry of regularEntries) {
-            entries.push(entry);
-        }
+    }
+
+    for (const entry of regularEntries) {
+        entries.push(entry);
     }
 
     if (probableEntries.length > 0) {

--- a/test/widgets/connectionsList.test.tsx
+++ b/test/widgets/connectionsList.test.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import { describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-react';
+
+import { type Translation, TranslationProvider } from '../../src/coreUtils/i18n';
+import { ConnectionsList } from '../../src/widgets/connectionsMenu/connectionList';
+import {
+    WorkspaceContext,
+    type WorkspaceContext as WorkspaceContextType,
+} from '../../src/workspace/workspaceContext';
+
+const link = {id: 'iri', label: []};
+const translation = {
+    formatLabel: () => 'relation',
+    text: (key: string) => key,
+} as unknown as Translation;
+const workspace = {
+    model: {
+        language: 'en',
+        locale: {formatIri: (value: string) => value},
+        operations: [],
+        getLinkType: () => undefined,
+        getOperationFailReason: () => undefined,
+        events: {
+            on: () => undefined,
+            off: () => undefined,
+        },
+    },
+} as unknown as WorkspaceContextType;
+
+describe('ConnectionsList', () => {
+    it('renders the only connection link', async () => {
+        await render(
+            <TranslationProvider translation={translation}>
+                <WorkspaceContext.Provider value={workspace}>
+                    <ConnectionsList
+                        data={{
+                            links: [link],
+                            counts: new Map([[link.id, {inCount: 1, outCount: 0, inexact: false}]]),
+                        }}
+                        filterKey=''
+                        sortMode='alphabet'
+                        suggestions={{filterKey: null, scores: new Map()}}
+                        allRelatedLink={{id: 'all', label: []}}
+                        onExpandLink={() => undefined}
+                        onMoveToFilter={undefined}
+                        scrolledListRef={React.createRef<HTMLUListElement>()}
+                    />
+                </WorkspaceContext.Provider>
+            </TranslationProvider>
+        );
+
+        expect(document.body.textContent).toContain('relation');
+    });
+});

--- a/test/widgets/connectionsList.test.tsx
+++ b/test/widgets/connectionsList.test.tsx
@@ -2,54 +2,38 @@ import * as React from 'react';
 import { describe, expect, it } from 'vitest';
 import { render } from 'vitest-browser-react';
 
-import { type Translation, TranslationProvider } from '../../src/coreUtils/i18n';
+import type { LinkTypeModel } from '../../src/data/model';
 import { ConnectionsList } from '../../src/widgets/connectionsMenu/connectionList';
-import {
-    WorkspaceContext,
-    type WorkspaceContext as WorkspaceContextType,
-} from '../../src/workspace/workspaceContext';
-
-const link = {id: 'iri', label: []};
-const translation = {
-    formatLabel: () => 'relation',
-    text: (key: string) => key,
-} as unknown as Translation;
-const workspace = {
-    model: {
-        language: 'en',
-        locale: {formatIri: (value: string) => value},
-        operations: [],
-        getLinkType: () => undefined,
-        getOperationFailReason: () => undefined,
-        events: {
-            on: () => undefined,
-            off: () => undefined,
-        },
-    },
-} as unknown as WorkspaceContextType;
+import { WorkspaceProvider, createWorkspace } from '../../src/workspace/workspaceProvider';
+import { blockingDefaultLayout } from '../../src/layout-sync';
 
 describe('ConnectionsList', () => {
     it('renders the only connection link', async () => {
+        const link: LinkTypeModel = {id: 'urn:test:single-link', label: []};
+        const workspace = createWorkspace({
+            defaultLayout: blockingDefaultLayout,
+        });
+
         await render(
-            <TranslationProvider translation={translation}>
-                <WorkspaceContext.Provider value={workspace}>
-                    <ConnectionsList
-                        data={{
-                            links: [link],
-                            counts: new Map([[link.id, {inCount: 1, outCount: 0, inexact: false}]]),
-                        }}
-                        filterKey=''
-                        sortMode='alphabet'
-                        suggestions={{filterKey: null, scores: new Map()}}
-                        allRelatedLink={{id: 'all', label: []}}
-                        onExpandLink={() => undefined}
-                        onMoveToFilter={undefined}
-                        scrolledListRef={React.createRef<HTMLUListElement>()}
-                    />
-                </WorkspaceContext.Provider>
-            </TranslationProvider>
+            <WorkspaceProvider workspace={workspace}>
+                <ConnectionsList
+                    data={{
+                        links: [link],
+                        counts: new Map([
+                            [link.id, {inCount: 1, outCount: 0, inexact: false}]
+                        ]),
+                    }}
+                    filterKey=''
+                    sortMode='alphabet'
+                    suggestions={{filterKey: null, scores: new Map()}}
+                    allRelatedLink={{id: 'all', label: []}}
+                    onExpandLink={() => undefined}
+                />
+            </WorkspaceProvider>
         );
 
-        expect(document.body.textContent).toContain('relation');
+        expect(document.body.querySelector(
+            '[data-linktypeid="urn:test:single-link"]'
+        )).toBeTruthy();
     });
 });


### PR DESCRIPTION
Fixes the connections list so a single incoming/outgoing link is rendered, currently entities with one link shows 'no results'. 
 
Disclaimer: The test was created by an LLM. 